### PR TITLE
One approach to making the library work on iOS

### DIFF
--- a/EnumerableExt.cs
+++ b/EnumerableExt.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RSG.Utils
+{
+    /// <summary>
+    /// General extensions to LINQ.
+    /// </summary>
+    public static class EnumerableExt
+    {
+        public static IEnumerable<T> Empty<T>()
+        {
+            return new T[0];
+        }
+
+        public static IEnumerable<T> LazyEach<T>(this IEnumerable<T> source, Action<T> fn)
+        {
+            foreach (var item in source)
+            {
+                fn.Invoke(item);
+
+                yield return item;
+            }
+        }
+
+        public static void Each<T>(this IEnumerable<T> source, Action<T> fn)
+        {
+            foreach (var item in source)
+            {
+                fn.Invoke(item);
+            }
+        }
+
+        public static void Each<T>(this IEnumerable<T> source, Action<T, int> fn)
+        {
+            int index = 0;
+
+            foreach (T item in source)
+            {
+                fn.Invoke(item, index);
+                index++;
+            }
+        }
+    }
+}

--- a/Promise.cs
+++ b/Promise.cs
@@ -272,8 +272,8 @@ namespace RSG
         /// </summary>
         private void InvokeHandler<T>(Action<T> callback, IRejectable rejectable, T value)
         {
-            Argument.NotNull(() => callback);
-            Argument.NotNull(() => rejectable);            
+//            Argument.NotNull(() => callback);
+//            Argument.NotNull(() => rejectable);            
 
             try
             {
@@ -299,7 +299,7 @@ namespace RSG
         /// </summary>
         private void InvokeRejectHandlers(Exception ex)
         {
-            Argument.NotNull(() => ex);
+//            Argument.NotNull(() => ex);
 
             if (rejectHandlers != null)
             {
@@ -327,7 +327,7 @@ namespace RSG
         /// </summary>
         public void Reject(Exception ex)
         {
-            Argument.NotNull(() => ex);
+//            Argument.NotNull(() => ex);
 
             if (CurState != PromiseState.Pending)
             {
@@ -373,8 +373,8 @@ namespace RSG
         /// </summary>
         public void Done(Action<PromisedT> onResolved, Action<Exception> onRejected)
         {
-            Argument.NotNull(() => onResolved);
-            Argument.NotNull(() => onRejected);
+//            Argument.NotNull(() => onResolved);
+//            Argument.NotNull(() => onRejected);
 
             var resultPromise = new Promise<PromisedT>();
             resultPromise.WithName(Name);
@@ -389,7 +389,7 @@ namespace RSG
         /// </summary>
         public void Done(Action<PromisedT> onResolved)
         {
-            Argument.NotNull(() => onResolved);
+//            Argument.NotNull(() => onResolved);
 
             var resultPromise = new Promise<PromisedT>();
             resultPromise.WithName(Name);
@@ -428,7 +428,7 @@ namespace RSG
         /// </summary>
         public IPromise<PromisedT> Catch(Action<Exception> onRejected)
         {
-            Argument.NotNull(() => onRejected);
+//            Argument.NotNull(() => onRejected);
 
             var resultPromise = new Promise<PromisedT>();
             resultPromise.WithName(Name);
@@ -482,7 +482,7 @@ namespace RSG
         {
             // This version of the function must supply an onResolved.
             // Otherwise there is now way to get the converted value to pass to the resulting promise.
-            Argument.NotNull(() => onResolved); 
+//            Argument.NotNull(() => onResolved); 
 
             var resultPromise = new Promise<ConvertedT>();
             resultPromise.WithName(Name);
@@ -592,7 +592,7 @@ namespace RSG
         /// </summary>
         public IPromise<ConvertedT> Transform<ConvertedT>(Func<PromisedT, ConvertedT> transform)
         {
-            Argument.NotNull(() => transform);
+//            Argument.NotNull(() => transform);
 
             var resultPromise = new Promise<ConvertedT>();
             resultPromise.WithName(Name);
@@ -792,7 +792,7 @@ namespace RSG
         /// </summary>
         public static IPromise<PromisedT> Rejected(Exception ex)
         {
-            Argument.NotNull(() => ex);
+//            Argument.NotNull(() => ex);
 
             var promise = new Promise<PromisedT>();
             promise.Reject(ex);

--- a/Promise.cs
+++ b/Promise.cs
@@ -160,30 +160,15 @@ namespace RSG
         private PromisedT resolveValue;
 
         /// <summary>
-        /// Represents a handler invoked when the promise is resolved or rejected.
-        /// </summary>
-        public struct Handler<T>
-        {
-            /// <summary>
-            /// Callback fn.
-            /// </summary>
-            public Action<T> callback;
-
-            /// <summary>
-            /// The promise that is rejected when there is an error while invoking the handler.
-            /// </summary>
-            public IRejectable rejectable;
-        }
-
-        /// <summary>
         /// Error handler.
         /// </summary>
-        private List<Handler<Exception>> rejectHandlers;
+		private List<RejectHandler> rejectHandlers;
 
         /// <summary>
         /// Completed handlers that accept a value.
         /// </summary>
-        private List<Handler<PromisedT>> resolveHandlers;
+		private List<Action<PromisedT>> resolveCallbacks;
+		private List<IRejectable> resolveRejectables;
 
         /// <summary>
         /// ID of the promise, useful for debugging.
@@ -244,10 +229,10 @@ namespace RSG
         {
             if (rejectHandlers == null)
             {
-                rejectHandlers = new List<Handler<Exception>>();
+				rejectHandlers = new List<RejectHandler>();
             }
 
-            rejectHandlers.Add(new Handler<Exception>() { callback = onRejected, rejectable = rejectable }); ;
+			rejectHandlers.Add(new RejectHandler() { callback = onRejected, rejectable = rejectable }); ;
         }
 
         /// <summary>
@@ -255,16 +240,18 @@ namespace RSG
         /// </summary>
         private void AddResolveHandler(Action<PromisedT> onResolved, IRejectable rejectable)
         {
-            if (resolveHandlers == null)
-            {
-                resolveHandlers = new List<Handler<PromisedT>>();
-            }
+			if (resolveCallbacks == null)
+			{
+				resolveCallbacks = new List<Action<PromisedT>>();
+			}
 
-            resolveHandlers.Add(new Handler<PromisedT>() 
-            { 
-                callback = onResolved,
-                rejectable = rejectable 
-            });
+			if (resolveRejectables == null)
+			{
+				resolveRejectables = new List<IRejectable>();
+			}
+
+			resolveCallbacks.Add(onResolved);
+			resolveRejectables.Add(rejectable);
         }
 
         /// <summary>
@@ -291,7 +278,8 @@ namespace RSG
         private void ClearHandlers()
         {
             rejectHandlers = null;
-            resolveHandlers = null;
+			resolveCallbacks = null;
+			resolveRejectables = null;
         }
 
         /// <summary>
@@ -314,9 +302,11 @@ namespace RSG
         /// </summary>
         private void InvokeResolveHandlers(PromisedT value)
         {
-            if (resolveHandlers != null)
+			if (resolveCallbacks != null)
             {
-                resolveHandlers.Each(handler => InvokeHandler(handler.callback, handler.rejectable, value));
+				for (int i = 0, maxI = resolveCallbacks.Count; i < maxI; i++) {
+					InvokeHandler(resolveCallbacks[i], resolveRejectables[i], value);
+				}
             }
 
             ClearHandlers();
@@ -672,7 +662,7 @@ namespace RSG
             var promisesArray = promises.ToArray();
             if (promisesArray.Length == 0)
             {
-                return Promise<IEnumerable<PromisedT>>.Resolved(LinqExts.Empty<PromisedT>());
+                return Promise<IEnumerable<PromisedT>>.Resolved(EnumerableExt.Empty<PromisedT>());
             }
 
             var remainingCount = promisesArray.Length;

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -144,7 +144,7 @@ namespace RSG
     {
         internal ExceptionEventArgs(Exception exception)
         {
-            Argument.NotNull(() => exception);
+//            Argument.NotNull(() => exception);
 
             this.Exception = exception;
         }
@@ -331,8 +331,8 @@ namespace RSG
         /// </summary>
         private void InvokeRejectHandler(Action<Exception> callback, IRejectable rejectable, Exception value)
         {
-            Argument.NotNull(() => callback);
-            Argument.NotNull(() => rejectable);
+//            Argument.NotNull(() => callback);
+//            Argument.NotNull(() => rejectable);
 
             try
             {
@@ -349,8 +349,8 @@ namespace RSG
         /// </summary>
         private void InvokeResolveHandler(Action callback, IRejectable rejectable)
         {
-            Argument.NotNull(() => callback);
-            Argument.NotNull(() => rejectable);
+//            Argument.NotNull(() => callback);
+//            Argument.NotNull(() => rejectable);
 
             try
             {
@@ -376,7 +376,7 @@ namespace RSG
         /// </summary>
         private void InvokeRejectHandlers(Exception ex)
         {
-            Argument.NotNull(() => ex);
+//            Argument.NotNull(() => ex);
 
             if (rejectHandlers != null)
             {
@@ -404,7 +404,7 @@ namespace RSG
         /// </summary>
         public void Reject(Exception ex)
         {
-            Argument.NotNull(() => ex);
+//            Argument.NotNull(() => ex);
 
             if (CurState != PromiseState.Pending)
             {
@@ -450,8 +450,8 @@ namespace RSG
         /// </summary>
         public void Done(Action onResolved, Action<Exception> onRejected)
         {
-            Argument.NotNull(() => onResolved);
-            Argument.NotNull(() => onRejected);
+//            Argument.NotNull(() => onResolved);
+//            Argument.NotNull(() => onRejected);
 
             var resultPromise = new Promise();
             resultPromise.WithName(Name);
@@ -466,7 +466,7 @@ namespace RSG
         /// </summary>
         public void Done(Action onResolved)
         {
-            Argument.NotNull(() => onResolved);
+//            Argument.NotNull(() => onResolved);
 
             var resultPromise = new Promise();
             resultPromise.WithName(Name);
@@ -505,7 +505,7 @@ namespace RSG
         /// </summary>
         public IPromise Catch(Action<Exception> onRejected)
         {
-            Argument.NotNull(() => onRejected);
+//            Argument.NotNull(() => onRejected);
 
             var resultPromise = new Promise();
             resultPromise.WithName(Name);
@@ -559,7 +559,7 @@ namespace RSG
         {
             // This version of the function must supply an onResolved.
             // Otherwise there is now way to get the converted value to pass to the resulting promise.
-            Argument.NotNull(() => onResolved);
+//            Argument.NotNull(() => onResolved);
 
             var resultPromise = new Promise<ConvertedT>();
             resultPromise.WithName(Name);
@@ -872,7 +872,7 @@ namespace RSG
         /// </summary>
         public static IPromise Rejected(Exception ex)
         {
-            Argument.NotNull(() => ex);
+//            Argument.NotNull(() => ex);
 
             var promise = new Promise();
             promise.Reject(ex);

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -156,6 +156,22 @@ namespace RSG
         }
     }
 
+	/// <summary>
+	/// Represents a handler invoked when the promise is rejected.
+	/// </summary>
+	public struct RejectHandler
+	{
+		/// <summary>
+		/// Callback fn.
+		/// </summary>
+		public Action<Exception> callback;
+
+		/// <summary>
+		/// The promise that is rejected when there is an error while invoking the handler.
+		/// </summary>
+		public IRejectable rejectable;
+	}
+
     /// <summary>
     /// Implements a non-generic C# promise, this is a promise that simply resolves without delivering a value.
     /// https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
@@ -201,22 +217,6 @@ namespace RSG
         /// The exception when the promise is rejected.
         /// </summary>
         private Exception rejectionException;
-
-        /// <summary>
-        /// Represents a handler invoked when the promise is rejected.
-        /// </summary>
-        public struct RejectHandler
-        {
-            /// <summary>
-            /// Callback fn.
-            /// </summary>
-            public Action<Exception> callback;
-
-            /// <summary>
-            /// The promise that is rejected when there is an error while invoking the handler.
-            /// </summary>
-            public IRejectable rejectable;
-        }
 
         /// <summary>
         /// Error handlers.

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -171,7 +171,12 @@ namespace RSG
         /// Event raised for unhandled errors.
         /// For this to work you have to complete your promises with a call to Done().
         /// </summary>
-        public static event EventHandler<ExceptionEventArgs> UnhandledException;
+        public static event EventHandler<ExceptionEventArgs> UnhandledException
+		{
+			add { unhandlerException += value; }
+			remove { unhandlerException -= value; }
+		}
+		private static EventHandler<ExceptionEventArgs> unhandlerException;
 
         /// <summary>
         /// Id for the next promise that is created.
@@ -879,9 +884,9 @@ namespace RSG
         /// </summary>
         internal static void PropagateUnhandledException(object sender, Exception ex)
         {
-            if (UnhandledException != null)
+			if (unhandlerException != null)
             {
-                UnhandledException(sender, new ExceptionEventArgs(ex));
+				unhandlerException(sender, new ExceptionEventArgs(ex));
             }
         }
     }


### PR DESCRIPTION
The internal Handler<T> class in the Promise<T> class was causing a lot of headache on iOS due to the compiler's inability to figure out usage during AOT compilation.  I picked that apart and reused the RejectHandler from non-generic Promise.  I also added specific add/remove methods to the UnhandledException event to fix issues with this when not using source.