### PR TITLE
Enforced done removal

### DIFF
--- a/Promise.cs
+++ b/Promise.cs
@@ -484,8 +484,7 @@ namespace RSG
 						// Should not be necessary to specify the arg type on the next line, but Unity (mono) has an internal compiler error otherwise.
                         (ConvertedT chainedValue) => resultPromise.Resolve(chainedValue),
                         ex => resultPromise.Reject(ex)
-                    )
-                    .Done();
+                    );
             };
 
             Action<Exception> rejectHandler = ex =>
@@ -520,8 +519,7 @@ namespace RSG
                         .Then(
                             () => resultPromise.Resolve(),
                             ex => resultPromise.Reject(ex)
-                        )
-                        .Done();
+                        );
                 }
                 else
                 {

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -571,8 +571,7 @@ namespace RSG
 						// Should not be necessary to specify the arg type on the next line, but Unity (mono) has an internal compiler error otherwise.
                         (ConvertedT chainedValue) => resultPromise.Resolve(chainedValue),
                         ex => resultPromise.Reject(ex)
-                    )
-                    .Done();
+                    );
             };
 
             Action<Exception> rejectHandler = ex =>
@@ -607,8 +606,7 @@ namespace RSG
                         .Then(
                             () => resultPromise.Resolve(),
                             ex => resultPromise.Reject(ex)
-                        )
-                        .Done();
+                        );
                 }
                 else
                 {

--- a/Tests/Promise_NonGeneric_Tests.cs
+++ b/Tests/Promise_NonGeneric_Tests.cs
@@ -450,7 +450,7 @@ namespace RSG.Tests
             var ex = new Exception();
 
             var transformedPromise = promise
-                .Then(() =>
+                .Then(() => 
                 {
                     throw ex;
                 })
@@ -495,7 +495,7 @@ namespace RSG.Tests
 
             promise
                 .Then(() => chainedPromise)
-                .Then(v =>
+                .Then(v => 
                 {
                     Assert.Equal(chainedPromiseValue, v);
 
@@ -728,12 +728,11 @@ namespace RSG.Tests
             var ex = new Exception();
 
             Promise
-                .Sequence(() =>
+                .Sequence(() => 
                 {
                     throw ex;
                 })
-                .Catch(e =>
-                {
+                .Catch(e => {
                     Assert.Equal(ex, e);
                     ++errored;
                 })
@@ -750,7 +749,7 @@ namespace RSG.Tests
 
             Promise
                 .Sequence(
-                    () =>
+                    () => 
                     {
                         ++completed;
                         return Promise.Resolved();


### PR DESCRIPTION
The enforced "Done" of the child promises created by Then() swallows exceptions which are meant to bubble up to the parent promise.

I also added tests which will fail on the master because the actually handled exception is passed to the unhandled-exceptions handler.