### PR TITLE
Updates

### DIFF
--- a/C-Sharp-Promise.csproj
+++ b/C-Sharp-Promise.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BasePromise.cs" />
     <Compile Include="EnumerableExt.cs" />
     <Compile Include="PromiseTimer.cs" />
     <Compile Include="Promise_NonGeneric.cs" />

--- a/C-Sharp-Promise.csproj
+++ b/C-Sharp-Promise.csproj
@@ -41,7 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="BasePromise.cs" />
+    <Compile Include="Promise_Base.cs" />
     <Compile Include="EnumerableExt.cs" />
     <Compile Include="PromiseTimer.cs" />
     <Compile Include="Promise_NonGeneric.cs" />

--- a/Promise.cs
+++ b/Promise.cs
@@ -694,7 +694,7 @@ namespace RSG
 		/// <summary>
 		/// Convert an exception directly into a rejected promise.
 		/// </summary>
-		new public static IPromise<PromisedT> Rejected(Exception ex)
+		public static IPromise<PromisedT> Rejected(Exception ex)
 		{
 //            Argument.NotNull(() => ex);
 

--- a/Promise.cs
+++ b/Promise.cs
@@ -111,7 +111,19 @@ namespace RSG
 		/// Yields the value from the first promise that has resolved.
 		/// </summary>
 		IPromise ThenRace(Func<PromisedT, IEnumerable<IPromise>> chain);
-	}
+
+        /// <summary>
+        /// Add a finally callback.
+        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+        /// </summary>
+        new IPromise Finally(Action onComplete);
+
+        /// <summary>
+        /// Add a finally callback.
+        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+        /// </summary>
+        IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete);
+    }
 
 	/// <summary>
 	/// Interface for a promise that can be rejected or resolved.
@@ -702,5 +714,34 @@ namespace RSG
 			promise.Reject(ex);
 			return promise;
 		}
-	}
+
+        public IPromise Finally(Action onComplete)
+        {
+            Promise promise = new Promise();
+
+            Promise<PromisedT>.Race(
+                this.Then((x) => { promise.Resolve(); }),
+                this.Catch((e) => { promise.Resolve(); })
+            );
+            
+            return promise.Then(onComplete);
+        }
+
+        public IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete)
+        {
+            Promise promise = new Promise();
+
+            Promise<PromisedT>.Race(
+                this.Then((x) => { promise.Resolve(); }),
+                this.Catch((e) => { promise.Resolve(); })
+            );
+
+            return promise.Then(onComplete);
+        }
+
+        IPromiseBase IPromiseBase.Finally(Action onComplete)
+        {
+            return Finally(onComplete);
+        }
+    }
 }

--- a/Promise.cs
+++ b/Promise.cs
@@ -720,10 +720,8 @@ namespace RSG
             Promise promise = new Promise();
             promise.WithName(Name);
 
-            Promise<PromisedT>.Race(
-                this.Then((x) => { promise.Resolve(); }),
-                this.Catch((e) => { promise.Resolve(); })
-            );
+            this.Then((x) => { promise.Resolve(); });
+            this.Catch((e) => { promise.Resolve(); });
             
             return promise.Then(onComplete);
         }
@@ -733,10 +731,8 @@ namespace RSG
             Promise promise = new Promise();
             promise.WithName(Name);
 
-            Promise<PromisedT>.Race(
-                this.Then((x) => { promise.Resolve(); }),
-                this.Catch((e) => { promise.Resolve(); })
-            );
+            this.Then((x) => { promise.Resolve(); });
+            this.Catch((e) => { promise.Resolve(); });
 
             return promise.Then(onComplete);
         }

--- a/Promise.cs
+++ b/Promise.cs
@@ -141,8 +141,8 @@ namespace RSG
 		private List<Action<PromisedT>> resolveCallbacks;
 		private List<IRejectable> resolveRejectables;
 
-        public Promise() : base()
-        { }
+		public Promise() : base()
+		{ }
 
 		public Promise(Action<Action<PromisedT>, Action<Exception>> resolver) : this()
 		{
@@ -186,7 +186,7 @@ namespace RSG
 		/// </summary>
 		protected override void ClearHandlers()
 		{
-            base.ClearHandlers();
+			base.ClearHandlers();
 			resolveCallbacks = null;
 			resolveRejectables = null;
 		}
@@ -253,55 +253,55 @@ namespace RSG
 				);
 		}
 
-        /// <summary>
-        /// Completes the promise. 
-        /// onResolved is called on successful completion.
-        /// onRejected is called on error.
-        /// </summary>
-        void IPromiseBase.Done(Action<PromiseResult> onResolved, Action<Exception> onRejected)
-        {
-            Then((x) => { onResolved(new PromiseResult(x)); }, onRejected)
-                .Catch(ex =>
-                    Promise.PropagateUnhandledException(this, ex)
-                );
-        }
+		/// <summary>
+		/// Completes the promise. 
+		/// onResolved is called on successful completion.
+		/// onRejected is called on error.
+		/// </summary>
+		void IPromiseBase.Done(Action<PromiseResult> onResolved, Action<Exception> onRejected)
+		{
+			Then((x) => { onResolved(new PromiseResult(x)); }, onRejected)
+				.Catch(ex =>
+					Promise.PropagateUnhandledException(this, ex)
+				);
+		}
 
-        /// <summary>
-        /// Completes the promise. 
-        /// onResolved is called on successful completion.
-        /// Adds a default error handler.
-        /// </summary>
-        void IPromiseBase.Done(Action<PromiseResult> onResolved)
-        {
-            Then((x) => { onResolved(new PromiseResult(x)); })
-                .Catch(ex =>
-                    Promise.PropagateUnhandledException(this, ex)
-                );
-        }
+		/// <summary>
+		/// Completes the promise. 
+		/// onResolved is called on successful completion.
+		/// Adds a default error handler.
+		/// </summary>
+		void IPromiseBase.Done(Action<PromiseResult> onResolved)
+		{
+			Then((x) => { onResolved(new PromiseResult(x)); })
+				.Catch(ex =>
+					Promise.PropagateUnhandledException(this, ex)
+				);
+		}
 
-        /// <summary>
-        /// Complete the promise. Adds a defualt error handler.
-        /// </summary>
-        public void Done()
-        {
-            Catch(ex =>
-                Promise.PropagateUnhandledException(this, ex)
-            );
-        }
+		/// <summary>
+		/// Complete the promise. Adds a defualt error handler.
+		/// </summary>
+		public void Done()
+		{
+			Catch(ex =>
+				Promise.PropagateUnhandledException(this, ex)
+			);
+		}
 
-        /// <summary>
-        /// Set the name of the promise, useful for debugging.
-        /// </summary>
-        public IPromise<PromisedT> WithName(string name)
+		/// <summary>
+		/// Set the name of the promise, useful for debugging.
+		/// </summary>
+		public IPromise<PromisedT> WithName(string name)
 		{
 			this.Name = name;
 			return this;
 		}
 
-        IPromiseBase IPromiseBase.WithName(string name)
-        {
-            return WithName(name);
-        }
+		IPromiseBase IPromiseBase.WithName(string name)
+		{
+			return WithName(name);
+		}
 
 		/// <summary>
 		/// Handle errors for the promise. 
@@ -330,10 +330,10 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Catch(Action<Exception> onRejected)
-        {
-            return Catch(onRejected);
-        }
+		IPromiseBase IPromiseBase.Catch(Action<Exception> onRejected)
+		{
+			return Catch(onRejected);
+		}
 
 		/// <summary>
 		/// Add a resolved callback that chains a value promise (optionally converting to a different value type).
@@ -351,10 +351,10 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-        IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved)
-        {
-            return Then((x) => { onResolved(new PromiseResult(x)); }, null);
-        }
+		IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved)
+		{
+			return Then((x) => { onResolved(new PromiseResult(x)); }, null);
+		}
 
 		/// <summary>
 		/// Add a resolved callback.
@@ -364,16 +364,16 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-        IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved)
-        {
-            return Then((x) => { onResolved(new PromiseResult(x)); }, null);
-        }
+		IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved)
+		{
+			return Then((x) => { onResolved(new PromiseResult(x)); }, null);
+		}
 
-        /// <summary>
-        /// Add a resolved callback and a rejected callback.
-        /// The resolved callback chains a value promise (optionally converting to a different value type).
-        /// </summary>
-        public IPromise<ConvertedT> Then<ConvertedT>(Func<PromisedT, IPromise<ConvertedT>> onResolved, Action<Exception> onRejected)
+		/// <summary>
+		/// Add a resolved callback and a rejected callback.
+		/// The resolved callback chains a value promise (optionally converting to a different value type).
+		/// </summary>
+		public IPromise<ConvertedT> Then<ConvertedT>(Func<PromisedT, IPromise<ConvertedT>> onResolved, Action<Exception> onRejected)
 		{
 			// This version of the function must supply an onResolved.
 			// Otherwise there is now way to get the converted value to pass to the resulting promise.
@@ -447,15 +447,15 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected)
-        {
-            return Then((x) => { onResolved(new PromiseResult(x)); }, onRejected);
-        }
+		IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected)
+		{
+			return Then((x) => { onResolved(new PromiseResult(x)); }, onRejected);
+		}
 
-        /// <summary>
-        /// Add a resolved callback and a rejected callback.
-        /// </summary>
-        public IPromise<PromisedT> Then(Action<PromisedT> onResolved, Action<Exception> onRejected)
+		/// <summary>
+		/// Add a resolved callback and a rejected callback.
+		/// </summary>
+		public IPromise<PromisedT> Then(Action<PromisedT> onResolved, Action<Exception> onRejected)
 		{
 			var resultPromise = new Promise<PromisedT>();
 			resultPromise.WithName(Name);
@@ -485,16 +485,16 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved, Action<Exception> onRejected)
-        {
-            return Then((x) => { onResolved(new PromiseResult(x)); }, onRejected);
-        }
+		IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved, Action<Exception> onRejected)
+		{
+			return Then((x) => { onResolved(new PromiseResult(x)); }, onRejected);
+		}
 
-        /// <summary>
-        /// Return a new promise with a different value.
-        /// May also change the type of the value.
-        /// </summary>
-        public IPromise<ConvertedT> Then<ConvertedT>(Func<PromisedT, ConvertedT> transform)
+		/// <summary>
+		/// Return a new promise with a different value.
+		/// May also change the type of the value.
+		/// </summary>
+		public IPromise<ConvertedT> Then<ConvertedT>(Func<PromisedT, ConvertedT> transform)
 		{
 //            Argument.NotNull(() => transform);
 			return Then(value => Promise<ConvertedT>.Resolved(transform(value)));
@@ -553,10 +553,10 @@ namespace RSG
 			return Then(value => Promise.All(chain(value)));
 		}
 
-        IPromiseBase IPromiseBase.ThenAll(Func<IEnumerable<IPromise>> chain)
-        {
-            return ThenAll((x) => { return chain(); });
-        }
+		IPromiseBase IPromiseBase.ThenAll(Func<IEnumerable<IPromise>> chain)
+		{
+			return ThenAll((x) => { return chain(); });
+		}
 
 		/// <summary>
 		/// Returns a promise that resolves when all of the promises in the enumerable argument have resolved.

--- a/Promise.cs
+++ b/Promise.cs
@@ -258,9 +258,9 @@ namespace RSG
         /// onResolved is called on successful completion.
         /// onRejected is called on error.
         /// </summary>
-        public void Done(Action onResolved, Action<Exception> onRejected)
+        void IPromiseBase.Done(Action<PromiseResult> onResolved, Action<Exception> onRejected)
         {
-            Then((x) => { onResolved(); }, onRejected)
+            Then((x) => { onResolved(new PromiseResult(x)); }, onRejected)
                 .Catch(ex =>
                     Promise.PropagateUnhandledException(this, ex)
                 );
@@ -271,9 +271,9 @@ namespace RSG
         /// onResolved is called on successful completion.
         /// Adds a default error handler.
         /// </summary>
-        public void Done(Action onResolved)
+        void IPromiseBase.Done(Action<PromiseResult> onResolved)
         {
-            Then((x) => { onResolved(); })
+            Then((x) => { onResolved(new PromiseResult(x)); })
                 .Catch(ex =>
                     Promise.PropagateUnhandledException(this, ex)
                 );
@@ -351,9 +351,9 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-        IPromiseBase IPromiseBase.Then(Func<IPromise> onResolved)
+        IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved)
         {
-            return Then((x) => { onResolved(); }, null);
+            return Then((x) => { onResolved(new PromiseResult(x)); }, null);
         }
 
 		/// <summary>
@@ -364,9 +364,9 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-        IPromiseBase IPromiseBase.Then(Action onResolved)
+        IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved)
         {
-            return Then((x) => { onResolved(); }, null);
+            return Then((x) => { onResolved(new PromiseResult(x)); }, null);
         }
 
         /// <summary>
@@ -447,9 +447,9 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Then(Func<IPromise> onResolved, Action<Exception> onRejected)
+        IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected)
         {
-            return Then((x) => { onResolved(); }, onRejected);
+            return Then((x) => { onResolved(new PromiseResult(x)); }, onRejected);
         }
 
         /// <summary>
@@ -485,9 +485,9 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Then(Action onResolved, Action<Exception> onRejected)
+        IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved, Action<Exception> onRejected)
         {
-            return Then((x) => { onResolved(); }, onRejected);
+            return Then((x) => { onResolved(new PromiseResult(x)); }, onRejected);
         }
 
         /// <summary>

--- a/Promise.cs
+++ b/Promise.cs
@@ -718,6 +718,7 @@ namespace RSG
         public IPromise Finally(Action onComplete)
         {
             Promise promise = new Promise();
+            promise.WithName(Name);
 
             Promise<PromisedT>.Race(
                 this.Then((x) => { promise.Resolve(); }),
@@ -730,6 +731,7 @@ namespace RSG
         public IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete)
         {
             Promise promise = new Promise();
+            promise.WithName(Name);
 
             Promise<PromisedT>.Race(
                 this.Then((x) => { promise.Resolve(); }),

--- a/Promise.cs
+++ b/Promise.cs
@@ -112,18 +112,18 @@ namespace RSG
 		/// </summary>
 		IPromise ThenRace(Func<PromisedT, IEnumerable<IPromise>> chain);
 
-        /// <summary>
-        /// Add a finally callback.
-        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
-        /// </summary>
-        new IPromise Finally(Action onComplete);
+		/// <summary>
+		/// Add a finally callback.
+		/// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+		/// </summary>
+		new IPromise Finally(Action onComplete);
 
-        /// <summary>
-        /// Add a finally callback.
-        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
-        /// </summary>
-        IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete);
-    }
+		/// <summary>
+		/// Add a finally callback.
+		/// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+		/// </summary>
+		IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete);
+	}
 
 	/// <summary>
 	/// Interface for a promise that can be rejected or resolved.
@@ -715,31 +715,31 @@ namespace RSG
 			return promise;
 		}
 
-        public IPromise Finally(Action onComplete)
-        {
-            Promise promise = new Promise();
-            promise.WithName(Name);
+		public IPromise Finally(Action onComplete)
+		{
+			Promise promise = new Promise();
+			promise.WithName(Name);
 
-            this.Then((x) => { promise.Resolve(); });
-            this.Catch((e) => { promise.Resolve(); });
-            
-            return promise.Then(onComplete);
-        }
+			this.Then((x) => { promise.Resolve(); });
+			this.Catch((e) => { promise.Resolve(); });
+			
+			return promise.Then(onComplete);
+		}
 
-        public IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete)
-        {
-            Promise promise = new Promise();
-            promise.WithName(Name);
+		public IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete)
+		{
+			Promise promise = new Promise();
+			promise.WithName(Name);
 
-            this.Then((x) => { promise.Resolve(); });
-            this.Catch((e) => { promise.Resolve(); });
+			this.Then((x) => { promise.Resolve(); });
+			this.Catch((e) => { promise.Resolve(); });
 
-            return promise.Then(onComplete);
-        }
+			return promise.Then(onComplete);
+		}
 
-        IPromiseBase IPromiseBase.Finally(Action onComplete)
-        {
-            return Finally(onComplete);
-        }
-    }
+		IPromiseBase IPromiseBase.Finally(Action onComplete)
+		{
+			return Finally(onComplete);
+		}
+	}
 }

--- a/Promise_Base.cs
+++ b/Promise_Base.cs
@@ -6,6 +6,9 @@ namespace RSG
 {
     public interface IPromiseBase
     {
+        /// <summary>
+        /// Set the name of the promise, useful for debugging.
+        /// </summary>
         IPromiseBase WithName(string name);
 
         /// <summary>

--- a/Promise_Base.cs
+++ b/Promise_Base.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using System.Collections.Generic;
+using RSG.Promises;
+
+namespace RSG
+{
+    public interface IPromiseBase
+    {
+        IPromiseBase WithName(string name);
+
+        /// <summary>
+        /// Completes the promise. 
+        /// onResolved is called on successful completion.
+        /// onRejected is called on error.
+        /// </summary>
+        void Done(Action onResolved, Action<Exception> onRejected);
+
+        /// <summary>
+        /// Completes the promise. 
+        /// onResolved is called on successful completion.
+        /// Adds a default error handler.
+        /// </summary>
+        void Done(Action onResolved);
+
+        /// <summary>
+        /// Complete the promise. Adds a default error handler.
+        /// </summary>
+        void Done();
+
+        /// <summary>
+        /// Handle errors for the promise. 
+        /// </summary>
+        IPromiseBase Catch(Action<Exception> onRejected);
+
+        /// <summary>
+        /// Add a resolved callback that chains a non-value promise.
+        /// </summary>
+        IPromiseBase Then(Func<IPromise> onResolved);
+
+        /// <summary>
+        /// Add a resolved callback.
+        /// </summary>
+        IPromiseBase Then(Action onResolved);
+
+        /// <summary>
+        /// Add a resolved callback and a rejected callback.
+        /// The resolved callback chains a non-value promise.
+        /// </summary>
+        IPromiseBase Then(Func<IPromise> onResolved, Action<Exception> onRejected);
+
+        /// <summary>
+        /// Add a resolved callback and a rejected callback.
+        /// </summary>
+        IPromiseBase Then(Action onResolved, Action<Exception> onRejected);
+
+        /// <summary>
+        /// Chain an enumerable of promises, all of which must resolve.
+        /// The resulting promise is resolved when all of the promises have resolved.
+        /// It is rejected as soon as any of the promises have been rejected.
+        /// </summary>
+        IPromiseBase ThenAll(Func<IEnumerable<IPromise>> chain);
+    }
+
+    /// <summary>
+    /// Interface for a promise that can be rejected.
+    /// </summary>
+    public interface IRejectable
+    {
+        /// <summary>
+        /// Reject the promise with an exception.
+        /// </summary>
+        void Reject(Exception ex);
+    }
+
+    /// <summary>
+    /// Arguments to the UnhandledError event.
+    /// </summary>
+    public class ExceptionEventArgs : EventArgs
+    {
+        internal ExceptionEventArgs(Exception exception)
+        {
+            //            Argument.NotNull(() => exception);
+
+            this.Exception = exception;
+        }
+
+        public Exception Exception
+        {
+            get;
+            private set;
+        }
+    }
+
+    /// <summary>
+    /// Represents a handler invoked when the promise is rejected.
+    /// </summary>
+    public struct RejectHandler
+    {
+        /// <summary>
+        /// Callback fn.
+        /// </summary>
+        public Action<Exception> callback;
+
+        /// <summary>
+        /// The promise that is rejected when there is an error while invoking the handler.
+        /// </summary>
+        public IRejectable rejectable;
+    }
+
+    /// <summary>
+    /// Specifies the state of a promise.
+    /// </summary>
+    public enum PromiseState
+    {
+        Pending,    // The promise is in-flight.
+        Rejected,   // The promise has been rejected.
+        Resolved    // The promise has been resolved.
+    };
+
+    /// <summary>
+    /// Used to list information of pending promises.
+    /// </summary>
+    public interface IPromiseInfo
+    {
+        /// <summary>
+        /// Id of the promise.
+        /// </summary>
+        int Id { get; }
+
+        /// <summary>
+        /// Human-readable name for the promise.
+        /// </summary>
+        string Name { get; }
+    }
+
+    public abstract class Promise_Base : IPromiseInfo
+    {
+        /// <summary>
+        /// The exception when the promise is rejected.
+        /// </summary>
+        protected Exception rejectionException;
+
+        /// <summary>
+        /// Error handlers.
+        /// </summary>
+        protected List<RejectHandler> rejectHandlers;
+
+        /// <summary>
+        /// ID of the promise, useful for debugging.
+        /// </summary>
+        public int Id { get; protected set; }
+
+        /// <summary>
+        /// Name of the promise, when set, useful for debugging.
+        /// </summary>
+        public string Name { get; protected set; }
+
+        /// <summary>
+        /// Tracks the current state of the promise.
+        /// </summary>
+        public PromiseState CurState { get; protected set; }
+
+        public Promise_Base()
+        {
+            this.CurState = PromiseState.Pending;
+            this.Id = ++Promise.nextPromiseId;
+
+            if (Promise.EnablePromiseTracking)
+            {
+                Promise.pendingPromises.Add(this);
+            }
+        }
+
+        /// <summary>
+        /// Add a rejection handler for this promise.
+        /// </summary>
+        protected void AddRejectHandler(Action<Exception> onRejected, IRejectable rejectable)
+        {
+            if (rejectHandlers == null)
+            {
+                rejectHandlers = new List<RejectHandler>();
+            }
+
+            rejectHandlers.Add(new RejectHandler()
+            {
+                callback = onRejected,
+                rejectable = rejectable
+            });
+        }
+
+        /// <summary>
+        /// Invoke a single handler.
+        /// </summary>
+        protected void InvokeHandler<T>(Action<T> callback, IRejectable rejectable, T value)
+        {
+            //            Argument.NotNull(() => callback);
+            //            Argument.NotNull(() => rejectable);            
+
+            try
+            {
+                callback(value);
+            }
+            catch (Exception ex)
+            {
+                rejectable.Reject(ex);
+            }
+        }
+
+        protected virtual void ClearHandlers()
+        {
+            rejectHandlers = null;
+        }
+
+        /// <summary>
+        /// Invoke all reject handlers.
+        /// </summary>
+        protected void InvokeRejectHandlers(Exception ex)
+        {
+            //            Argument.NotNull(() => ex);
+
+            if (rejectHandlers != null)
+            {
+                rejectHandlers.Each(handler => InvokeHandler(handler.callback, handler.rejectable, ex));
+            }
+
+            ClearHandlers();
+        }
+
+        /// <summary>
+        /// Reject the promise with an exception.
+        /// </summary>
+        public void Reject(Exception ex)
+        {
+            //            Argument.NotNull(() => ex);
+
+            if (CurState != PromiseState.Pending)
+            {
+                throw new ApplicationException("Attempt to reject a promise that is already in state: " + CurState + ", a promise can only be rejected when it is still in state: " + PromiseState.Pending);
+            }
+
+            rejectionException = ex;
+            CurState = PromiseState.Rejected;
+
+            if (Promise.EnablePromiseTracking)
+            {
+                Promise.pendingPromises.Remove(this);
+            }
+
+            InvokeRejectHandlers(ex);
+        }
+    }
+}

--- a/Promise_Base.cs
+++ b/Promise_Base.cs
@@ -4,271 +4,271 @@ using RSG.Promises;
 
 namespace RSG
 {
-    public interface IPromiseBase
-    {
-        /// <summary>
-        /// Set the name of the promise, useful for debugging.
-        /// </summary>
-        IPromiseBase WithName(string name);
+	public interface IPromiseBase
+	{
+		/// <summary>
+		/// Set the name of the promise, useful for debugging.
+		/// </summary>
+		IPromiseBase WithName(string name);
 
-        /// <summary>
-        /// Completes the promise. 
-        /// onResolved is called on successful completion.
-        /// onRejected is called on error.
-        /// </summary>
-        void Done(Action<PromiseResult> onResolved, Action<Exception> onRejected);
+		/// <summary>
+		/// Completes the promise. 
+		/// onResolved is called on successful completion.
+		/// onRejected is called on error.
+		/// </summary>
+		void Done(Action<PromiseResult> onResolved, Action<Exception> onRejected);
 
-        /// <summary>
-        /// Completes the promise. 
-        /// onResolved is called on successful completion.
-        /// Adds a default error handler.
-        /// </summary>
-        void Done(Action<PromiseResult> onResolved);
+		/// <summary>
+		/// Completes the promise. 
+		/// onResolved is called on successful completion.
+		/// Adds a default error handler.
+		/// </summary>
+		void Done(Action<PromiseResult> onResolved);
 
-        /// <summary>
-        /// Complete the promise. Adds a default error handler.
-        /// </summary>
-        void Done();
+		/// <summary>
+		/// Complete the promise. Adds a default error handler.
+		/// </summary>
+		void Done();
 
-        /// <summary>
-        /// Handle errors for the promise. 
-        /// </summary>
-        IPromiseBase Catch(Action<Exception> onRejected);
+		/// <summary>
+		/// Handle errors for the promise. 
+		/// </summary>
+		IPromiseBase Catch(Action<Exception> onRejected);
 
-        /// <summary>
-        /// Add a resolved callback that chains a non-value promise.
-        /// </summary>
-        IPromiseBase Then(Func<PromiseResult, IPromise> onResolved);
+		/// <summary>
+		/// Add a resolved callback that chains a non-value promise.
+		/// </summary>
+		IPromiseBase Then(Func<PromiseResult, IPromise> onResolved);
 
-        /// <summary>
-        /// Add a resolved callback.
-        /// </summary>
-        IPromiseBase Then(Action<PromiseResult> onResolved);
+		/// <summary>
+		/// Add a resolved callback.
+		/// </summary>
+		IPromiseBase Then(Action<PromiseResult> onResolved);
 
-        /// <summary>
-        /// Add a resolved callback and a rejected callback.
-        /// The resolved callback chains a non-value promise.
-        /// </summary>
-        IPromiseBase Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected);
+		/// <summary>
+		/// Add a resolved callback and a rejected callback.
+		/// The resolved callback chains a non-value promise.
+		/// </summary>
+		IPromiseBase Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected);
 
-        /// <summary>
-        /// Add a resolved callback and a rejected callback.
-        /// </summary>
-        IPromiseBase Then(Action<PromiseResult> onResolved, Action<Exception> onRejected);
+		/// <summary>
+		/// Add a resolved callback and a rejected callback.
+		/// </summary>
+		IPromiseBase Then(Action<PromiseResult> onResolved, Action<Exception> onRejected);
 
-        /// <summary>
-        /// Chain an enumerable of promises, all of which must resolve.
-        /// The resulting promise is resolved when all of the promises have resolved.
-        /// It is rejected as soon as any of the promises have been rejected.
-        /// </summary>
-        IPromiseBase ThenAll(Func<IEnumerable<IPromise>> chain);
-    }
+		/// <summary>
+		/// Chain an enumerable of promises, all of which must resolve.
+		/// The resulting promise is resolved when all of the promises have resolved.
+		/// It is rejected as soon as any of the promises have been rejected.
+		/// </summary>
+		IPromiseBase ThenAll(Func<IEnumerable<IPromise>> chain);
+	}
 
-    /// <summary>
-    /// Interface for a promise that can be rejected.
-    /// </summary>
-    public interface IRejectable
-    {
-        /// <summary>
-        /// Reject the promise with an exception.
-        /// </summary>
-        void Reject(Exception ex);
-    }
+	/// <summary>
+	/// Interface for a promise that can be rejected.
+	/// </summary>
+	public interface IRejectable
+	{
+		/// <summary>
+		/// Reject the promise with an exception.
+		/// </summary>
+		void Reject(Exception ex);
+	}
 
-    /// <summary>
-    /// Arguments to the UnhandledError event.
-    /// </summary>
-    public class ExceptionEventArgs : EventArgs
-    {
-        internal ExceptionEventArgs(Exception exception)
-        {
-            //            Argument.NotNull(() => exception);
+	/// <summary>
+	/// Arguments to the UnhandledError event.
+	/// </summary>
+	public class ExceptionEventArgs : EventArgs
+	{
+		internal ExceptionEventArgs(Exception exception)
+		{
+			//            Argument.NotNull(() => exception);
 
-            this.Exception = exception;
-        }
+			this.Exception = exception;
+		}
 
-        public Exception Exception
-        {
-            get;
-            private set;
-        }
-    }
+		public Exception Exception
+		{
+			get;
+			private set;
+		}
+	}
 
-    /// <summary>
-    /// Represents a handler invoked when the promise is rejected.
-    /// </summary>
-    public struct RejectHandler
-    {
-        /// <summary>
-        /// Callback fn.
-        /// </summary>
-        public Action<Exception> callback;
+	/// <summary>
+	/// Represents a handler invoked when the promise is rejected.
+	/// </summary>
+	public struct RejectHandler
+	{
+		/// <summary>
+		/// Callback fn.
+		/// </summary>
+		public Action<Exception> callback;
 
-        /// <summary>
-        /// The promise that is rejected when there is an error while invoking the handler.
-        /// </summary>
-        public IRejectable rejectable;
-    }
+		/// <summary>
+		/// The promise that is rejected when there is an error while invoking the handler.
+		/// </summary>
+		public IRejectable rejectable;
+	}
 
-    public class PromiseResult
-    {
-        public static readonly PromiseResult None = new PromiseResult();
+	public class PromiseResult
+	{
+		public static readonly PromiseResult None = new PromiseResult();
 
-        public readonly bool hasValue;
-        public readonly object Result;
+		public readonly bool hasValue;
+		public readonly object Result;
 
-        public PromiseResult()
-        {
-            hasValue = false;
-        }
+		public PromiseResult()
+		{
+			hasValue = false;
+		}
 
-        public PromiseResult(object value)
-        {
-            hasValue = true;
-            Result = value;
-        }
-    }
+		public PromiseResult(object value)
+		{
+			hasValue = true;
+			Result = value;
+		}
+	}
 
-    /// <summary>
-    /// Specifies the state of a promise.
-    /// </summary>
-    public enum PromiseState
-    {
-        Pending,    // The promise is in-flight.
-        Rejected,   // The promise has been rejected.
-        Resolved    // The promise has been resolved.
-    };
+	/// <summary>
+	/// Specifies the state of a promise.
+	/// </summary>
+	public enum PromiseState
+	{
+		Pending,    // The promise is in-flight.
+		Rejected,   // The promise has been rejected.
+		Resolved    // The promise has been resolved.
+	};
 
-    /// <summary>
-    /// Used to list information of pending promises.
-    /// </summary>
-    public interface IPromiseInfo
-    {
-        /// <summary>
-        /// Id of the promise.
-        /// </summary>
-        int Id { get; }
+	/// <summary>
+	/// Used to list information of pending promises.
+	/// </summary>
+	public interface IPromiseInfo
+	{
+		/// <summary>
+		/// Id of the promise.
+		/// </summary>
+		int Id { get; }
 
-        /// <summary>
-        /// Human-readable name for the promise.
-        /// </summary>
-        string Name { get; }
-    }
+		/// <summary>
+		/// Human-readable name for the promise.
+		/// </summary>
+		string Name { get; }
+	}
 
-    public abstract class Promise_Base : IPromiseInfo
-    {
-        /// <summary>
-        /// The exception when the promise is rejected.
-        /// </summary>
-        protected Exception rejectionException;
+	public abstract class Promise_Base : IPromiseInfo
+	{
+		/// <summary>
+		/// The exception when the promise is rejected.
+		/// </summary>
+		protected Exception rejectionException;
 
-        /// <summary>
-        /// Error handlers.
-        /// </summary>
-        protected List<RejectHandler> rejectHandlers;
+		/// <summary>
+		/// Error handlers.
+		/// </summary>
+		protected List<RejectHandler> rejectHandlers;
 
-        /// <summary>
-        /// ID of the promise, useful for debugging.
-        /// </summary>
-        public int Id { get; protected set; }
+		/// <summary>
+		/// ID of the promise, useful for debugging.
+		/// </summary>
+		public int Id { get; protected set; }
 
-        /// <summary>
-        /// Name of the promise, when set, useful for debugging.
-        /// </summary>
-        public string Name { get; protected set; }
+		/// <summary>
+		/// Name of the promise, when set, useful for debugging.
+		/// </summary>
+		public string Name { get; protected set; }
 
-        /// <summary>
-        /// Tracks the current state of the promise.
-        /// </summary>
-        public PromiseState CurState { get; protected set; }
+		/// <summary>
+		/// Tracks the current state of the promise.
+		/// </summary>
+		public PromiseState CurState { get; protected set; }
 
-        public Promise_Base()
-        {
-            this.CurState = PromiseState.Pending;
-            this.Id = ++Promise.nextPromiseId;
+		public Promise_Base()
+		{
+			this.CurState = PromiseState.Pending;
+			this.Id = ++Promise.nextPromiseId;
 
-            if (Promise.EnablePromiseTracking)
-            {
-                Promise.pendingPromises.Add(this);
-            }
-        }
+			if (Promise.EnablePromiseTracking)
+			{
+				Promise.pendingPromises.Add(this);
+			}
+		}
 
-        /// <summary>
-        /// Add a rejection handler for this promise.
-        /// </summary>
-        protected void AddRejectHandler(Action<Exception> onRejected, IRejectable rejectable)
-        {
-            if (rejectHandlers == null)
-            {
-                rejectHandlers = new List<RejectHandler>();
-            }
+		/// <summary>
+		/// Add a rejection handler for this promise.
+		/// </summary>
+		protected void AddRejectHandler(Action<Exception> onRejected, IRejectable rejectable)
+		{
+			if (rejectHandlers == null)
+			{
+				rejectHandlers = new List<RejectHandler>();
+			}
 
-            rejectHandlers.Add(new RejectHandler()
-            {
-                callback = onRejected,
-                rejectable = rejectable
-            });
-        }
+			rejectHandlers.Add(new RejectHandler()
+			{
+				callback = onRejected,
+				rejectable = rejectable
+			});
+		}
 
-        /// <summary>
-        /// Invoke a single handler.
-        /// </summary>
-        protected void InvokeHandler<T>(Action<T> callback, IRejectable rejectable, T value)
-        {
-            //            Argument.NotNull(() => callback);
-            //            Argument.NotNull(() => rejectable);            
+		/// <summary>
+		/// Invoke a single handler.
+		/// </summary>
+		protected void InvokeHandler<T>(Action<T> callback, IRejectable rejectable, T value)
+		{
+			//            Argument.NotNull(() => callback);
+			//            Argument.NotNull(() => rejectable);            
 
-            try
-            {
-                callback(value);
-            }
-            catch (Exception ex)
-            {
-                rejectable.Reject(ex);
-            }
-        }
+			try
+			{
+				callback(value);
+			}
+			catch (Exception ex)
+			{
+				rejectable.Reject(ex);
+			}
+		}
 
-        protected virtual void ClearHandlers()
-        {
-            rejectHandlers = null;
-        }
+		protected virtual void ClearHandlers()
+		{
+			rejectHandlers = null;
+		}
 
-        /// <summary>
-        /// Invoke all reject handlers.
-        /// </summary>
-        protected void InvokeRejectHandlers(Exception ex)
-        {
-            //            Argument.NotNull(() => ex);
+		/// <summary>
+		/// Invoke all reject handlers.
+		/// </summary>
+		protected void InvokeRejectHandlers(Exception ex)
+		{
+			//            Argument.NotNull(() => ex);
 
-            if (rejectHandlers != null)
-            {
-                rejectHandlers.Each(handler => InvokeHandler(handler.callback, handler.rejectable, ex));
-            }
+			if (rejectHandlers != null)
+			{
+				rejectHandlers.Each(handler => InvokeHandler(handler.callback, handler.rejectable, ex));
+			}
 
-            ClearHandlers();
-        }
+			ClearHandlers();
+		}
 
-        /// <summary>
-        /// Reject the promise with an exception.
-        /// </summary>
-        public void Reject(Exception ex)
-        {
-            //            Argument.NotNull(() => ex);
+		/// <summary>
+		/// Reject the promise with an exception.
+		/// </summary>
+		public void Reject(Exception ex)
+		{
+			//            Argument.NotNull(() => ex);
 
-            if (CurState != PromiseState.Pending)
-            {
-                throw new ApplicationException("Attempt to reject a promise that is already in state: " + CurState + ", a promise can only be rejected when it is still in state: " + PromiseState.Pending);
-            }
+			if (CurState != PromiseState.Pending)
+			{
+				throw new ApplicationException("Attempt to reject a promise that is already in state: " + CurState + ", a promise can only be rejected when it is still in state: " + PromiseState.Pending);
+			}
 
-            rejectionException = ex;
-            CurState = PromiseState.Rejected;
+			rejectionException = ex;
+			CurState = PromiseState.Rejected;
 
-            if (Promise.EnablePromiseTracking)
-            {
-                Promise.pendingPromises.Remove(this);
-            }
+			if (Promise.EnablePromiseTracking)
+			{
+				Promise.pendingPromises.Remove(this);
+			}
 
-            InvokeRejectHandlers(ex);
-        }
-    }
+			InvokeRejectHandlers(ex);
+		}
+	}
 }

--- a/Promise_Base.cs
+++ b/Promise_Base.cs
@@ -63,12 +63,12 @@ namespace RSG
 		/// </summary>
 		IPromiseBase ThenAll(Func<IEnumerable<IPromise>> chain);
 
-        /// <summary>
-        /// Add a finally callback.
-        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
-        /// </summary>
-        IPromiseBase Finally(Action onComplete);
-    }
+		/// <summary>
+		/// Add a finally callback.
+		/// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+		/// </summary>
+		IPromiseBase Finally(Action onComplete);
+	}
 
 	/// <summary>
 	/// Interface for a promise that can be rejected.

--- a/Promise_Base.cs
+++ b/Promise_Base.cs
@@ -62,7 +62,13 @@ namespace RSG
 		/// It is rejected as soon as any of the promises have been rejected.
 		/// </summary>
 		IPromiseBase ThenAll(Func<IEnumerable<IPromise>> chain);
-	}
+
+        /// <summary>
+        /// Add a finally callback.
+        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+        /// </summary>
+        IPromiseBase Finally(Action onComplete);
+    }
 
 	/// <summary>
 	/// Interface for a promise that can be rejected.

--- a/Promise_Base.cs
+++ b/Promise_Base.cs
@@ -16,14 +16,14 @@ namespace RSG
         /// onResolved is called on successful completion.
         /// onRejected is called on error.
         /// </summary>
-        void Done(Action onResolved, Action<Exception> onRejected);
+        void Done(Action<PromiseResult> onResolved, Action<Exception> onRejected);
 
         /// <summary>
         /// Completes the promise. 
         /// onResolved is called on successful completion.
         /// Adds a default error handler.
         /// </summary>
-        void Done(Action onResolved);
+        void Done(Action<PromiseResult> onResolved);
 
         /// <summary>
         /// Complete the promise. Adds a default error handler.
@@ -38,23 +38,23 @@ namespace RSG
         /// <summary>
         /// Add a resolved callback that chains a non-value promise.
         /// </summary>
-        IPromiseBase Then(Func<IPromise> onResolved);
+        IPromiseBase Then(Func<PromiseResult, IPromise> onResolved);
 
         /// <summary>
         /// Add a resolved callback.
         /// </summary>
-        IPromiseBase Then(Action onResolved);
+        IPromiseBase Then(Action<PromiseResult> onResolved);
 
         /// <summary>
         /// Add a resolved callback and a rejected callback.
         /// The resolved callback chains a non-value promise.
         /// </summary>
-        IPromiseBase Then(Func<IPromise> onResolved, Action<Exception> onRejected);
+        IPromiseBase Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected);
 
         /// <summary>
         /// Add a resolved callback and a rejected callback.
         /// </summary>
-        IPromiseBase Then(Action onResolved, Action<Exception> onRejected);
+        IPromiseBase Then(Action<PromiseResult> onResolved, Action<Exception> onRejected);
 
         /// <summary>
         /// Chain an enumerable of promises, all of which must resolve.
@@ -108,6 +108,25 @@ namespace RSG
         /// The promise that is rejected when there is an error while invoking the handler.
         /// </summary>
         public IRejectable rejectable;
+    }
+
+    public class PromiseResult
+    {
+        public static readonly PromiseResult None = new PromiseResult();
+
+        public readonly bool hasValue;
+        public readonly object Result;
+
+        public PromiseResult()
+        {
+            hasValue = false;
+        }
+
+        public PromiseResult(object value)
+        {
+            hasValue = true;
+            Result = value;
+        }
     }
 
     /// <summary>

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -104,18 +104,18 @@ namespace RSG
 		/// </summary>
 		IPromise<ConvertedT> ThenRace<ConvertedT>(Func<IEnumerable<IPromise<ConvertedT>>> chain);
 
-        /// <summary>
-        /// Add a finally callback.
-        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
-        /// </summary>
-        new IPromise Finally(Action onComplete);
+		/// <summary>
+		/// Add a finally callback.
+		/// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+		/// </summary>
+		new IPromise Finally(Action onComplete);
 
-        /// <summary>
-        /// Add a finally callback.
-        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
-        /// </summary>
-        IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete);
-    }
+		/// <summary>
+		/// Add a finally callback.
+		/// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+		/// </summary>
+		IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete);
+	}
 
 	/// <summary>
 	/// Interface for a promise that can be rejected or resolved.
@@ -801,31 +801,31 @@ namespace RSG
 			}
 		}
 
-        public IPromise Finally(Action onComplete)
-        {
-            Promise promise = new Promise();
-            promise.WithName(Name);
+		public IPromise Finally(Action onComplete)
+		{
+			Promise promise = new Promise();
+			promise.WithName(Name);
 
-            this.Then(() => { promise.Resolve(); });
-            this.Catch((e) => { promise.Resolve(); });
+			this.Then(() => { promise.Resolve(); });
+			this.Catch((e) => { promise.Resolve(); });
 
-            return promise.Then(onComplete);
-        }
+			return promise.Then(onComplete);
+		}
 
-        public IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete)
-        {
-            Promise promise = new Promise();
-            promise.WithName(Name);
+		public IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete)
+		{
+			Promise promise = new Promise();
+			promise.WithName(Name);
 
-            this.Then(() => { promise.Resolve(); });
-            this.Catch((e) => { promise.Resolve(); });
+			this.Then(() => { promise.Resolve(); });
+			this.Catch((e) => { promise.Resolve(); });
 
-            return promise.Then(() => { return onComplete(); });
-        }
+			return promise.Then(() => { return onComplete(); });
+		}
 
-        IPromiseBase IPromiseBase.Finally(Action onComplete)
-        {
-            return Finally(onComplete);
-        }
-    }
+		IPromiseBase IPromiseBase.Finally(Action onComplete)
+		{
+			return Finally(onComplete);
+		}
+	}
 }

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -804,6 +804,7 @@ namespace RSG
         public IPromise Finally(Action onComplete)
         {
             Promise promise = new Promise();
+            promise.WithName(Name);
 
             Promise.Race(
                 this.Then(() => { promise.Resolve(); }),
@@ -816,6 +817,7 @@ namespace RSG
         public IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete)
         {
             Promise promise = new Promise();
+            promise.WithName(Name);
 
             Promise.Race(
                 this.Then(() => { promise.Resolve(); }),

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -18,6 +18,20 @@ namespace RSG
 		new IPromise WithName(string name);
 
         /// <summary>
+        /// Completes the promise. 
+        /// onResolved is called on successful completion.
+        /// onRejected is called on error.
+        /// </summary>
+        void Done(Action onResolved, Action<Exception> onRejected);
+
+        /// <summary>
+        /// Completes the promise. 
+        /// onResolved is called on successful completion.
+        /// Adds a default error handler.
+        /// </summary>
+        void Done(Action onResolved);
+
+        /// <summary>
         /// Handle errors for the promise. 
         /// </summary>
         new IPromise Catch(Action<Exception> onRejected);
@@ -30,12 +44,12 @@ namespace RSG
         /// <summary>
         /// Add a resolved callback that chains a non-value promise.
         /// </summary>
-        new IPromise Then(Func<IPromise> onResolved);
+        IPromise Then(Func<IPromise> onResolved);
 
         /// <summary>
         /// Add a resolved callback.
         /// </summary>
-        new IPromise Then(Action onResolved);
+        IPromise Then(Action onResolved);
 
 		/// <summary>
 		/// Add a resolved callback and a rejected callback.
@@ -47,12 +61,12 @@ namespace RSG
         /// Add a resolved callback and a rejected callback.
         /// The resolved callback chains a non-value promise.
         /// </summary>
-        new IPromise Then(Func<IPromise> onResolved, Action<Exception> onRejected);
+        IPromise Then(Func<IPromise> onResolved, Action<Exception> onRejected);
 
         /// <summary>
         /// Add a resolved callback and a rejected callback.
         /// </summary>
-        new IPromise Then(Action onResolved, Action<Exception> onRejected);
+        IPromise Then(Action onResolved, Action<Exception> onRejected);
 
         /// <summary>
         /// Chain an enumerable of promises, all of which must resolve.
@@ -306,10 +320,36 @@ namespace RSG
 				);
 		}
 
-		/// <summary>
-		/// Complete the promise. Adds a defualt error handler.
-		/// </summary>
-		public void Done()
+        /// <summary>
+        /// Completes the promise. 
+        /// onResolved is called on successful completion.
+        /// onRejected is called on error.
+        /// </summary>
+        void IPromiseBase.Done(Action<PromiseResult> onResolved, Action<Exception> onRejected)
+        {
+            Then(() => { onResolved(PromiseResult.None); }, onRejected)
+                .Catch(ex =>
+                    Promise.PropagateUnhandledException(this, ex)
+                );
+        }
+
+        /// <summary>
+        /// Completes the promise. 
+        /// onResolved is called on successful completion.
+        /// Adds a default error handler.
+        /// </summary>
+        void IPromiseBase.Done(Action<PromiseResult> onResolved)
+        {
+            Then(() => { onResolved(PromiseResult.None); })
+                .Catch(ex =>
+                    Promise.PropagateUnhandledException(this, ex)
+                );
+        }
+
+        /// <summary>
+        /// Complete the promise. Adds a defualt error handler.
+        /// </summary>
+        public void Done()
 		{
 			Catch(ex =>
 				Promise.PropagateUnhandledException(this, ex)
@@ -378,9 +418,9 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-        IPromiseBase IPromiseBase.Then(Func<IPromise> onResolved)
+        IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved)
         {
-            return Then(onResolved);
+            return Then(() => { onResolved(PromiseResult.None); });
         }
 
 		/// <summary>
@@ -391,9 +431,9 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-        IPromiseBase IPromiseBase.Then(Action onResolved)
+        IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved)
         {
-            return Then(onResolved);
+            return Then(() => { onResolved(PromiseResult.None); });
         }
 
         /// <summary>
@@ -474,9 +514,9 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Then(Func<IPromise> onResolved, Action<Exception> onRejected)
+        IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected)
         {
-            return Then(onResolved, onRejected);
+            return Then(() => { onResolved(PromiseResult.None); }, onRejected);
         }
 
 		/// <summary>
@@ -512,9 +552,9 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Then(Action onResolved, Action<Exception> onRejected)
+        IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved, Action<Exception> onRejected)
         {
-            return Then(onResolved, onRejected);
+            return Then(() => { onResolved(PromiseResult.None); }, onRejected);
         }
 
         /// <summary>

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -17,39 +17,39 @@ namespace RSG
 		/// </summary>
 		new IPromise WithName(string name);
 
-        /// <summary>
-        /// Completes the promise. 
-        /// onResolved is called on successful completion.
-        /// onRejected is called on error.
-        /// </summary>
-        void Done(Action onResolved, Action<Exception> onRejected);
+		/// <summary>
+		/// Completes the promise. 
+		/// onResolved is called on successful completion.
+		/// onRejected is called on error.
+		/// </summary>
+		void Done(Action onResolved, Action<Exception> onRejected);
 
-        /// <summary>
-        /// Completes the promise. 
-        /// onResolved is called on successful completion.
-        /// Adds a default error handler.
-        /// </summary>
-        void Done(Action onResolved);
+		/// <summary>
+		/// Completes the promise. 
+		/// onResolved is called on successful completion.
+		/// Adds a default error handler.
+		/// </summary>
+		void Done(Action onResolved);
 
-        /// <summary>
-        /// Handle errors for the promise. 
-        /// </summary>
-        new IPromise Catch(Action<Exception> onRejected);
+		/// <summary>
+		/// Handle errors for the promise. 
+		/// </summary>
+		new IPromise Catch(Action<Exception> onRejected);
 
 		/// <summary>
 		/// Add a resolved callback that chains a value promise (optionally converting to a different value type).
 		/// </summary>
 		IPromise<ConvertedT> Then<ConvertedT>(Func<IPromise<ConvertedT>> onResolved);
 
-        /// <summary>
-        /// Add a resolved callback that chains a non-value promise.
-        /// </summary>
-        IPromise Then(Func<IPromise> onResolved);
+		/// <summary>
+		/// Add a resolved callback that chains a non-value promise.
+		/// </summary>
+		IPromise Then(Func<IPromise> onResolved);
 
-        /// <summary>
-        /// Add a resolved callback.
-        /// </summary>
-        IPromise Then(Action onResolved);
+		/// <summary>
+		/// Add a resolved callback.
+		/// </summary>
+		IPromise Then(Action onResolved);
 
 		/// <summary>
 		/// Add a resolved callback and a rejected callback.
@@ -57,23 +57,23 @@ namespace RSG
 		/// </summary>
 		IPromise<ConvertedT> Then<ConvertedT>(Func<IPromise<ConvertedT>> onResolved, Action<Exception> onRejected);
 
-        /// <summary>
-        /// Add a resolved callback and a rejected callback.
-        /// The resolved callback chains a non-value promise.
-        /// </summary>
-        IPromise Then(Func<IPromise> onResolved, Action<Exception> onRejected);
+		/// <summary>
+		/// Add a resolved callback and a rejected callback.
+		/// The resolved callback chains a non-value promise.
+		/// </summary>
+		IPromise Then(Func<IPromise> onResolved, Action<Exception> onRejected);
 
-        /// <summary>
-        /// Add a resolved callback and a rejected callback.
-        /// </summary>
-        IPromise Then(Action onResolved, Action<Exception> onRejected);
+		/// <summary>
+		/// Add a resolved callback and a rejected callback.
+		/// </summary>
+		IPromise Then(Action onResolved, Action<Exception> onRejected);
 
-        /// <summary>
-        /// Chain an enumerable of promises, all of which must resolve.
-        /// The resulting promise is resolved when all of the promises have resolved.
-        /// It is rejected as soon as any of the promises have been rejected.
-        /// </summary>
-        new IPromise ThenAll(Func<IEnumerable<IPromise>> chain);
+		/// <summary>
+		/// Chain an enumerable of promises, all of which must resolve.
+		/// The resulting promise is resolved when all of the promises have resolved.
+		/// It is rejected as soon as any of the promises have been rejected.
+		/// </summary>
+		new IPromise ThenAll(Func<IEnumerable<IPromise>> chain);
 
 		/// <summary>
 		/// Chain an enumerable of promises, all of which must resolve.
@@ -257,7 +257,7 @@ namespace RSG
 		/// </summary>
 		override protected void ClearHandlers()
 		{
-            base.ClearHandlers();
+			base.ClearHandlers();
 			resolveHandlers = null;
 		}
 
@@ -320,36 +320,36 @@ namespace RSG
 				);
 		}
 
-        /// <summary>
-        /// Completes the promise. 
-        /// onResolved is called on successful completion.
-        /// onRejected is called on error.
-        /// </summary>
-        void IPromiseBase.Done(Action<PromiseResult> onResolved, Action<Exception> onRejected)
-        {
-            Then(() => { onResolved(PromiseResult.None); }, onRejected)
-                .Catch(ex =>
-                    Promise.PropagateUnhandledException(this, ex)
-                );
-        }
+		/// <summary>
+		/// Completes the promise. 
+		/// onResolved is called on successful completion.
+		/// onRejected is called on error.
+		/// </summary>
+		void IPromiseBase.Done(Action<PromiseResult> onResolved, Action<Exception> onRejected)
+		{
+			Then(() => { onResolved(PromiseResult.None); }, onRejected)
+				.Catch(ex =>
+					Promise.PropagateUnhandledException(this, ex)
+				);
+		}
 
-        /// <summary>
-        /// Completes the promise. 
-        /// onResolved is called on successful completion.
-        /// Adds a default error handler.
-        /// </summary>
-        void IPromiseBase.Done(Action<PromiseResult> onResolved)
-        {
-            Then(() => { onResolved(PromiseResult.None); })
-                .Catch(ex =>
-                    Promise.PropagateUnhandledException(this, ex)
-                );
-        }
+		/// <summary>
+		/// Completes the promise. 
+		/// onResolved is called on successful completion.
+		/// Adds a default error handler.
+		/// </summary>
+		void IPromiseBase.Done(Action<PromiseResult> onResolved)
+		{
+			Then(() => { onResolved(PromiseResult.None); })
+				.Catch(ex =>
+					Promise.PropagateUnhandledException(this, ex)
+				);
+		}
 
-        /// <summary>
-        /// Complete the promise. Adds a defualt error handler.
-        /// </summary>
-        public void Done()
+		/// <summary>
+		/// Complete the promise. Adds a defualt error handler.
+		/// </summary>
+		public void Done()
 		{
 			Catch(ex =>
 				Promise.PropagateUnhandledException(this, ex)
@@ -365,10 +365,10 @@ namespace RSG
 			return this;
 		}
 
-        IPromiseBase IPromiseBase.WithName(string name)
-        {
-            return WithName(name);
-        }
+		IPromiseBase IPromiseBase.WithName(string name)
+		{
+			return WithName(name);
+		}
 
 		/// <summary>
 		/// Handle errors for the promise. 
@@ -397,10 +397,10 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Catch(Action<Exception> onRejected)
-        {
-            return Catch(onRejected);
-        }
+		IPromiseBase IPromiseBase.Catch(Action<Exception> onRejected)
+		{
+			return Catch(onRejected);
+		}
 
 		/// <summary>
 		/// Add a resolved callback that chains a value promise (optionally converting to a different value type).
@@ -418,10 +418,10 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-        IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved)
-        {
-            return Then(() => { onResolved(PromiseResult.None); });
-        }
+		IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved)
+		{
+			return Then(() => { onResolved(PromiseResult.None); });
+		}
 
 		/// <summary>
 		/// Add a resolved callback.
@@ -431,16 +431,16 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-        IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved)
-        {
-            return Then(() => { onResolved(PromiseResult.None); });
-        }
+		IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved)
+		{
+			return Then(() => { onResolved(PromiseResult.None); });
+		}
 
-        /// <summary>
-        /// Add a resolved callback and a rejected callback.
-        /// The resolved callback chains a value promise (optionally converting to a different value type).
-        /// </summary>
-        public IPromise<ConvertedT> Then<ConvertedT>(Func<IPromise<ConvertedT>> onResolved, Action<Exception> onRejected)
+		/// <summary>
+		/// Add a resolved callback and a rejected callback.
+		/// The resolved callback chains a value promise (optionally converting to a different value type).
+		/// </summary>
+		public IPromise<ConvertedT> Then<ConvertedT>(Func<IPromise<ConvertedT>> onResolved, Action<Exception> onRejected)
 		{
 			// This version of the function must supply an onResolved.
 			// Otherwise there is now way to get the converted value to pass to the resulting promise.
@@ -514,10 +514,10 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected)
-        {
-            return Then(() => { onResolved(PromiseResult.None); }, onRejected);
-        }
+		IPromiseBase IPromiseBase.Then(Func<PromiseResult, IPromise> onResolved, Action<Exception> onRejected)
+		{
+			return Then(() => { onResolved(PromiseResult.None); }, onRejected);
+		}
 
 		/// <summary>
 		/// Add a resolved callback and a rejected callback.
@@ -552,15 +552,15 @@ namespace RSG
 			return resultPromise;
 		}
 
-        IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved, Action<Exception> onRejected)
-        {
-            return Then(() => { onResolved(PromiseResult.None); }, onRejected);
-        }
+		IPromiseBase IPromiseBase.Then(Action<PromiseResult> onResolved, Action<Exception> onRejected)
+		{
+			return Then(() => { onResolved(PromiseResult.None); }, onRejected);
+		}
 
-        /// <summary>
-        /// Helper function to invoke or register resolve/reject handlers.
-        /// </summary>
-        private void ActionHandlers(IRejectable resultPromise, Action resolveHandler, Action<Exception> rejectHandler)
+		/// <summary>
+		/// Helper function to invoke or register resolve/reject handlers.
+		/// </summary>
+		private void ActionHandlers(IRejectable resultPromise, Action resolveHandler, Action<Exception> rejectHandler)
 		{
 			if (CurState == PromiseState.Resolved)
 			{
@@ -587,10 +587,10 @@ namespace RSG
 			return Then(() => Promise.All(chain()));
 		}
 
-        IPromiseBase IPromiseBase.ThenAll(Func<IEnumerable<IPromise>> chain)
-        {
-            return ThenAll(chain);
-        }
+		IPromiseBase IPromiseBase.ThenAll(Func<IEnumerable<IPromise>> chain)
+		{
+			return ThenAll(chain);
+		}
 
 		/// <summary>
 		/// Chain an enumerable of promises, all of which must resolve.

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -806,10 +806,8 @@ namespace RSG
             Promise promise = new Promise();
             promise.WithName(Name);
 
-            Promise.Race(
-                this.Then(() => { promise.Resolve(); }),
-                this.Catch((e) => { promise.Resolve(); })
-            );
+            this.Then(() => { promise.Resolve(); });
+            this.Catch((e) => { promise.Resolve(); });
 
             return promise.Then(onComplete);
         }
@@ -819,10 +817,8 @@ namespace RSG
             Promise promise = new Promise();
             promise.WithName(Name);
 
-            Promise.Race(
-                this.Then(() => { promise.Resolve(); }),
-                this.Catch((e) => { promise.Resolve(); })
-            );
+            this.Then(() => { promise.Resolve(); });
+            this.Catch((e) => { promise.Resolve(); });
 
             return promise.Then(() => { return onComplete(); });
         }

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -10,51 +10,32 @@ namespace RSG
 	/// Implements a non-generic C# promise, this is a promise that simply resolves without delivering a value.
 	/// https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
 	/// </summary>
-	public interface IPromise
+	public interface IPromise : IPromiseBase
 	{
 		/// <summary>
 		/// Set the name of the promise, useful for debugging.
 		/// </summary>
-		IPromise WithName(string name);
+		new IPromise WithName(string name);
 
-		/// <summary>
-		/// Completes the promise. 
-		/// onResolved is called on successful completion.
-		/// onRejected is called on error.
-		/// </summary>
-		void Done(Action onResolved, Action<Exception> onRejected);
-
-		/// <summary>
-		/// Completes the promise. 
-		/// onResolved is called on successful completion.
-		/// Adds a default error handler.
-		/// </summary>
-		void Done(Action onResolved);
-
-		/// <summary>
-		/// Complete the promise. Adds a default error handler.
-		/// </summary>
-		void Done();
-
-		/// <summary>
-		/// Handle errors for the promise. 
-		/// </summary>
-		IPromise Catch(Action<Exception> onRejected);
+        /// <summary>
+        /// Handle errors for the promise. 
+        /// </summary>
+        new IPromise Catch(Action<Exception> onRejected);
 
 		/// <summary>
 		/// Add a resolved callback that chains a value promise (optionally converting to a different value type).
 		/// </summary>
 		IPromise<ConvertedT> Then<ConvertedT>(Func<IPromise<ConvertedT>> onResolved);
 
-		/// <summary>
-		/// Add a resolved callback that chains a non-value promise.
-		/// </summary>
-		IPromise Then(Func<IPromise> onResolved);
+        /// <summary>
+        /// Add a resolved callback that chains a non-value promise.
+        /// </summary>
+        new IPromise Then(Func<IPromise> onResolved);
 
-		/// <summary>
-		/// Add a resolved callback.
-		/// </summary>
-		IPromise Then(Action onResolved);
+        /// <summary>
+        /// Add a resolved callback.
+        /// </summary>
+        new IPromise Then(Action onResolved);
 
 		/// <summary>
 		/// Add a resolved callback and a rejected callback.
@@ -62,23 +43,23 @@ namespace RSG
 		/// </summary>
 		IPromise<ConvertedT> Then<ConvertedT>(Func<IPromise<ConvertedT>> onResolved, Action<Exception> onRejected);
 
-		/// <summary>
-		/// Add a resolved callback and a rejected callback.
-		/// The resolved callback chains a non-value promise.
-		/// </summary>
-		IPromise Then(Func<IPromise> onResolved, Action<Exception> onRejected);
+        /// <summary>
+        /// Add a resolved callback and a rejected callback.
+        /// The resolved callback chains a non-value promise.
+        /// </summary>
+        new IPromise Then(Func<IPromise> onResolved, Action<Exception> onRejected);
 
-		/// <summary>
-		/// Add a resolved callback and a rejected callback.
-		/// </summary>
-		IPromise Then(Action onResolved, Action<Exception> onRejected);
+        /// <summary>
+        /// Add a resolved callback and a rejected callback.
+        /// </summary>
+        new IPromise Then(Action onResolved, Action<Exception> onRejected);
 
-		/// <summary>
-		/// Chain an enumerable of promises, all of which must resolve.
-		/// The resulting promise is resolved when all of the promises have resolved.
-		/// It is rejected as soon as any of the promises have been rejected.
-		/// </summary>
-		IPromise ThenAll(Func<IEnumerable<IPromise>> chain);
+        /// <summary>
+        /// Chain an enumerable of promises, all of which must resolve.
+        /// The resulting promise is resolved when all of the promises have resolved.
+        /// It is rejected as soon as any of the promises have been rejected.
+        /// </summary>
+        new IPromise ThenAll(Func<IEnumerable<IPromise>> chain);
 
 		/// <summary>
 		/// Chain an enumerable of promises, all of which must resolve.
@@ -122,61 +103,10 @@ namespace RSG
 	}
 
 	/// <summary>
-	/// Used to list information of pending promises.
-	/// </summary>
-	public interface IPromiseInfo
-	{
-		/// <summary>
-		/// Id of the promise.
-		/// </summary>
-		int Id { get; }
-
-		/// <summary>
-		/// Human-readable name for the promise.
-		/// </summary>
-		string Name { get; }
-	}
-
-	/// <summary>
-	/// Arguments to the UnhandledError event.
-	/// </summary>
-	public class ExceptionEventArgs : EventArgs
-	{
-		internal ExceptionEventArgs(Exception exception)
-		{
-//            Argument.NotNull(() => exception);
-
-			this.Exception = exception;
-		}
-
-		public Exception Exception
-		{
-			get;
-			private set;
-		}
-	}
-
-	/// <summary>
-	/// Represents a handler invoked when the promise is rejected.
-	/// </summary>
-	public struct RejectHandler
-	{
-		/// <summary>
-		/// Callback fn.
-		/// </summary>
-		public Action<Exception> callback;
-
-		/// <summary>
-		/// The promise that is rejected when there is an error while invoking the handler.
-		/// </summary>
-		public IRejectable rejectable;
-	}
-
-	/// <summary>
 	/// Implements a non-generic C# promise, this is a promise that simply resolves without delivering a value.
 	/// https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
 	/// </summary>
-	public class Promise : IPromise, IPendingPromise, IPromiseInfo
+	public class Promise : Promise_Base, IPromise, IPendingPromise
 	{
 		/// <summary>
 		/// Set to true to enable tracking of promises.
@@ -214,16 +144,6 @@ namespace RSG
 		}
 
 		/// <summary>
-		/// The exception when the promise is rejected.
-		/// </summary>
-		private Exception rejectionException;
-
-		/// <summary>
-		/// Error handlers.
-		/// </summary>
-		private List<RejectHandler> rejectHandlers;
-
-		/// <summary>
 		/// Represents a handler invoked when the promise is resolved.
 		/// </summary>
 		public struct ResolveHandler
@@ -244,38 +164,11 @@ namespace RSG
 		/// </summary>
 		private List<ResolveHandler> resolveHandlers;
 
-		/// <summary>
-		/// ID of the promise, useful for debugging.
-		/// </summary>
-		public int Id { get; private set; }
+		public Promise() : base()
+		{ }
 
-		/// <summary>
-		/// Name of the promise, when set, useful for debugging.
-		/// </summary>
-		public string Name { get; private set; }
-
-		/// <summary>
-		/// Tracks the current state of the promise.
-		/// </summary>
-		public PromiseState CurState { get; private set; }
-
-		public Promise()
+		public Promise(Action<Action, Action<Exception>> resolver): this()
 		{
-			this.CurState = PromiseState.Pending;
-			if (EnablePromiseTracking)
-			{
-				pendingPromises.Add(this);
-			}
-		}
-
-		public Promise(Action<Action, Action<Exception>> resolver)
-		{
-			this.CurState = PromiseState.Pending;
-			if (EnablePromiseTracking)
-			{
-				pendingPromises.Add(this);
-			}
-
 			try
 			{
 				resolver(
@@ -290,23 +183,6 @@ namespace RSG
 			{
 				Reject(ex);
 			}
-		}
-
-		/// <summary>
-		/// Add a rejection handler for this promise.
-		/// </summary>
-		private void AddRejectHandler(Action<Exception> onRejected, IRejectable rejectable)
-		{
-			if (rejectHandlers == null)
-			{
-				rejectHandlers = new List<RejectHandler>();
-			}
-
-			rejectHandlers.Add(new RejectHandler()
-			{
-				callback = onRejected,
-				rejectable = rejectable
-			});
 		}
 
 		/// <summary>
@@ -365,25 +241,10 @@ namespace RSG
 		/// <summary>
 		/// Helper function clear out all handlers after resolution or rejection.
 		/// </summary>
-		private void ClearHandlers()
+		override protected void ClearHandlers()
 		{
-			rejectHandlers = null;
+            base.ClearHandlers();
 			resolveHandlers = null;
-		}
-
-		/// <summary>
-		/// Invoke all reject handlers.
-		/// </summary>
-		private void InvokeRejectHandlers(Exception ex)
-		{
-//            Argument.NotNull(() => ex);
-
-			if (rejectHandlers != null)
-			{
-				rejectHandlers.Each(handler => InvokeRejectHandler(handler.callback, handler.rejectable, ex));
-			}
-
-			ClearHandlers();
 		}
 
 		/// <summary>
@@ -398,30 +259,6 @@ namespace RSG
 
 			ClearHandlers();
 		}
-
-		/// <summary>
-		/// Reject the promise with an exception.
-		/// </summary>
-		public void Reject(Exception ex)
-		{
-//            Argument.NotNull(() => ex);
-
-			if (CurState != PromiseState.Pending)
-			{
-				throw new ApplicationException("Attempt to reject a promise that is already in state: " + CurState + ", a promise can only be rejected when it is still in state: " + PromiseState.Pending);
-			}
-
-			rejectionException = ex;
-			CurState = PromiseState.Rejected;
-
-			if (EnablePromiseTracking)
-			{
-				pendingPromises.Remove(this);
-			}
-
-			InvokeRejectHandlers(ex);            
-		}
-
 
 		/// <summary>
 		/// Resolve the promise with a particular value.
@@ -488,6 +325,11 @@ namespace RSG
 			return this;
 		}
 
+        IPromiseBase IPromiseBase.WithName(string name)
+        {
+            return WithName(name);
+        }
+
 		/// <summary>
 		/// Handle errors for the promise. 
 		/// </summary>
@@ -515,6 +357,11 @@ namespace RSG
 			return resultPromise;
 		}
 
+        IPromiseBase IPromiseBase.Catch(Action<Exception> onRejected)
+        {
+            return Catch(onRejected);
+        }
+
 		/// <summary>
 		/// Add a resolved callback that chains a value promise (optionally converting to a different value type).
 		/// </summary>
@@ -531,6 +378,11 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
+        IPromiseBase IPromiseBase.Then(Func<IPromise> onResolved)
+        {
+            return Then(onResolved);
+        }
+
 		/// <summary>
 		/// Add a resolved callback.
 		/// </summary>
@@ -539,11 +391,16 @@ namespace RSG
 			return Then(onResolved, null);
 		}
 
-		/// <summary>
-		/// Add a resolved callback and a rejected callback.
-		/// The resolved callback chains a value promise (optionally converting to a different value type).
-		/// </summary>
-		public IPromise<ConvertedT> Then<ConvertedT>(Func<IPromise<ConvertedT>> onResolved, Action<Exception> onRejected)
+        IPromiseBase IPromiseBase.Then(Action onResolved)
+        {
+            return Then(onResolved);
+        }
+
+        /// <summary>
+        /// Add a resolved callback and a rejected callback.
+        /// The resolved callback chains a value promise (optionally converting to a different value type).
+        /// </summary>
+        public IPromise<ConvertedT> Then<ConvertedT>(Func<IPromise<ConvertedT>> onResolved, Action<Exception> onRejected)
 		{
 			// This version of the function must supply an onResolved.
 			// Otherwise there is now way to get the converted value to pass to the resulting promise.
@@ -617,6 +474,11 @@ namespace RSG
 			return resultPromise;
 		}
 
+        IPromiseBase IPromiseBase.Then(Func<IPromise> onResolved, Action<Exception> onRejected)
+        {
+            return Then(onResolved, onRejected);
+        }
+
 		/// <summary>
 		/// Add a resolved callback and a rejected callback.
 		/// </summary>
@@ -650,10 +512,15 @@ namespace RSG
 			return resultPromise;
 		}
 
-		/// <summary>
-		/// Helper function to invoke or register resolve/reject handlers.
-		/// </summary>
-		private void ActionHandlers(IRejectable resultPromise, Action resolveHandler, Action<Exception> rejectHandler)
+        IPromiseBase IPromiseBase.Then(Action onResolved, Action<Exception> onRejected)
+        {
+            return Then(onResolved, onRejected);
+        }
+
+        /// <summary>
+        /// Helper function to invoke or register resolve/reject handlers.
+        /// </summary>
+        private void ActionHandlers(IRejectable resultPromise, Action resolveHandler, Action<Exception> rejectHandler)
 		{
 			if (CurState == PromiseState.Resolved)
 			{
@@ -679,6 +546,11 @@ namespace RSG
 		{
 			return Then(() => Promise.All(chain()));
 		}
+
+        IPromiseBase IPromiseBase.ThenAll(Func<IEnumerable<IPromise>> chain)
+        {
+            return ThenAll(chain);
+        }
 
 		/// <summary>
 		/// Chain an enumerable of promises, all of which must resolve.

--- a/Tests/PromiseTests.cs
+++ b/Tests/PromiseTests.cs
@@ -986,5 +986,100 @@ namespace RSG.Tests
             Assert.Equal(0, callback);
             Assert.Equal(1, errorCallback);
         }
+
+        [Fact]
+        public void finally_is_called_after_resolve()
+        {
+            var promise = new Promise<int>();
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+            }).Then((x) => { });
+
+            promise.Resolve(0);
+
+            Assert.Equal(1, callback);
+        }
+
+        [Fact]
+        public void finally_is_called_after_reject()
+        {
+            var promise = new Promise<int>();
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(1, callback);
+        }
+
+        [Fact]
+        public void resolved_chain_continues_after_finally()
+        {
+            var promise = new Promise<int>();
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+            })
+            .Then(() =>
+            {
+                ++callback;
+            });
+
+            promise.Resolve(0);
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        public void rejected_chain_continues_after_finally()
+        {
+            var promise = new Promise<int>();
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+            })
+            .Then(() =>
+            {
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        public void can_chain_promise_after_finally()
+        {
+            var promise = new Promise<int>();
+            var expectedValue = 5;
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+                return Promise<int>.Resolved(expectedValue);
+            })
+            .Then((x) =>
+            {
+                ++callback;
+                Assert.Equal(expectedValue, x);
+            });
+
+            promise.Resolve(0);
+
+            Assert.Equal(2, callback);
+        }
     }
 }

--- a/Tests/Promise_NonGeneric_Tests.cs
+++ b/Tests/Promise_NonGeneric_Tests.cs
@@ -1110,5 +1110,100 @@ namespace RSG.Tests
                 Promise.UnhandledException -= handler;
             }
         }
+
+        [Fact]
+        public void finally_is_called_after_resolve()
+        {
+            var promise = new Promise();
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+            });
+
+            promise.Resolve();
+
+            Assert.Equal(1, callback);
+        }
+
+        [Fact]
+        public void finally_is_called_after_reject()
+        {
+            var promise = new Promise();
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(1, callback);
+        }
+
+        [Fact]
+        public void resolved_chain_continues_after_finally()
+        {
+            var promise = new Promise();
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+            })
+            .Then(() =>
+            {
+                ++callback;
+            });
+
+            promise.Resolve();
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        public void rejected_chain_continues_after_finally()
+        {
+            var promise = new Promise();
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+            })
+            .Then(() =>
+            {
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        public void can_chain_promise_after_finally()
+        {
+            var promise = new Promise();
+            var expectedValue = 5;
+            var callback = 0;
+
+            promise.Finally(() =>
+            {
+                ++callback;
+                return Promise<int>.Resolved(expectedValue);
+            })
+            .Then((x) =>
+            {
+                ++callback;
+                Assert.Equal(expectedValue, x);
+            });
+
+            promise.Resolve();
+
+            Assert.Equal(2, callback);
+        }
     }
 }


### PR DESCRIPTION
I've implemented some changes that I needed for my project.
#### Create unified base class/interface for generic and non-generic promises

This allows code which can handle any type of promise. Creating IPromiseBase allows IPromise, IPromise<int>, and IPromise<MyFunClass> to all be treated identically, without creating code branches for each. The IPromiseBase interface is implemented explicitly, which avoids creating ambiguous functions.

Additionally, the Promise_Base class allows for a decent amount of code reuse between generic and non-generic promises.
#### Implement Finally

Implemented as described in issue #9. It's just a wrapper around existing functionality.
