### PR TITLE
Replace List<PredicateWait> by LinkedList<PredicateWait>

### DIFF
--- a/Tests/PromiseTimerTests.cs
+++ b/Tests/PromiseTimerTests.cs
@@ -175,7 +175,47 @@ namespace RSG.Tests
         }
 
         [Fact]
-        public void all_promises_are_updated_when_a_pending_promise_is_removed_during_update()
+        public void all_promises_are_updated_when_a_pending_promise_is_resolved_during_update()
+        {
+            var testObject = new PromiseTimer();
+
+            var p1Updates = 0;
+            var p2Updates = 0;
+            var p3Updates = 0;
+
+            testObject
+                .WaitUntil(timeData =>
+                {
+                    p1Updates++;
+
+                    return false;
+                });
+
+            testObject
+                .WaitUntil(timeData =>
+                {
+                    p2Updates++;
+
+                    return true;
+                });
+
+            testObject
+                .WaitUntil(timeData =>
+                {
+                    p3Updates++;
+
+                    return false;
+                });
+
+            testObject.Update(0.01f);
+
+            Assert.Equal(1, p1Updates);
+            Assert.Equal(1, p2Updates);
+            Assert.Equal(1, p3Updates);
+        }
+
+        [Fact]
+        public void all_promises_are_updated_when_a_pending_promise_is_canceled_during_update()
         {
             var testObject = new PromiseTimer();
 
@@ -191,16 +231,19 @@ namespace RSG.Tests
                     return false;
                 });
 
-            var p2 = testObject
+            testObject
                 .WaitUntil(timeData =>
                 {
                     p2Updates++;
-                    testObject.Cancel(p1);
 
-                    return false;
+                    return true;
+                })
+                .Then(() => 
+                {
+                    testObject.Cancel(p1);
                 });
 
-            var p3 = testObject
+            testObject
                 .WaitUntil(timeData =>
                 {
                     p3Updates++;

--- a/Tests/PromiseTimerTests.cs
+++ b/Tests/PromiseTimerTests.cs
@@ -173,5 +173,46 @@ namespace RSG.Tests
 
             Assert.Equal(expectedException, caughtException);
         }
+
+        [Fact]
+        public void all_promises_are_updated_when_a_pending_promise_is_removed_during_update()
+        {
+            var testObject = new PromiseTimer();
+
+            var p1Updates = 0;
+            var p2Updates = 0;
+            var p3Updates = 0;
+
+            var p1 = testObject
+                .WaitUntil(timeData =>
+                {
+                    p1Updates++;
+
+                    return false;
+                });
+
+            var p2 = testObject
+                .WaitUntil(timeData =>
+                {
+                    p2Updates++;
+                    testObject.Cancel(p1);
+
+                    return false;
+                });
+
+            var p3 = testObject
+                .WaitUntil(timeData =>
+                {
+                    p3Updates++;
+
+                    return false;
+                });
+
+            testObject.Update(0.01f);
+
+            Assert.Equal(1, p1Updates);
+            Assert.Equal(1, p2Updates);
+            Assert.Equal(1, p3Updates);
+        }
     }
 }


### PR DESCRIPTION
Replace List<PredicateWait> by LinkedList<PredicateWait> to avoid problems when concurrent modifications are made. This is possible when an PromiseTimer gets canceled within the callback chain of an resolved PromiseTimer. When the canceled PromiseTimer is located at a lower index within the List, then we ending up by removing an wrong PromiseTimer. This means that the already resolved promise is left in the list and an non resolved one is removed. The next Update() call will then lead into an Exception because of the already resolved promise and of course the removed promise is ending up being "dead".