### PR TITLE
Added "elapsedUpdates" to the TimeData class

### DIFF
--- a/PromiseTimer.cs
+++ b/PromiseTimer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace RSG
@@ -48,6 +48,11 @@ namespace RSG
         /// The time data specific to this pending promise. Includes elapsed time and delta time.
         /// </summary>
         public TimeData timeData;
+
+        /// <summary>
+        /// The frame the promise was started
+        /// </summary>
+        public int frameStarted;
     }
 
     /// <summary>
@@ -64,6 +69,11 @@ namespace RSG
         /// The amount of time since the last time the pending promise was updated.
         /// </summary>
         public float deltaTime;
+
+        /// <summary>
+        /// The amount of times that update has been called since the pending promise started running
+        /// </summary>
+        public int elapsedUpdates;
     }
 
     public interface IPromiseTimer
@@ -102,6 +112,11 @@ namespace RSG
         private float curTime;
 
         /// <summary>
+        /// The current running total for the amount of frames the PromiseTimer has run for
+        /// </summary>
+        private int curFrame;
+
+        /// <summary>
         /// Currently pending promises
         /// </summary>
         private LinkedList<PredicateWait> waiting = new LinkedList<PredicateWait>();
@@ -134,7 +149,8 @@ namespace RSG
                 timeStarted = curTime,
                 pendingPromise = promise,
                 timeData = new TimeData(),
-                predicate = predicate
+                predicate = predicate,
+                frameStarted = curFrame
             };
 
             waiting.AddLast(wait);
@@ -176,6 +192,7 @@ namespace RSG
         public void Update(float deltaTime)
         {
             curTime += deltaTime;
+            curFrame += 1;
 
             var node = waiting.First;
             while (node != null)
@@ -185,6 +202,8 @@ namespace RSG
                 var newElapsedTime = curTime - wait.timeStarted;
                 wait.timeData.deltaTime = newElapsedTime - wait.timeData.elapsedTime;
                 wait.timeData.elapsedTime = newElapsedTime;
+                var newElapsedUpdates = curFrame - wait.frameStarted;
+                wait.timeData.elapsedUpdates = newElapsedUpdates;
 
                 bool result;
                 try

--- a/README.md
+++ b/README.md
@@ -513,7 +513,13 @@ WaitUntil takes a predicate to check each update and resolves once the predicate
 
 WaitFor is exactly the same as WaitUntil except that it resolves when its predicate function returns false. Think of WaitUntil as running *until* its predicate returns true, and WaitWhile as running *while* its predicate returns true, stopping when it is false.
 
+### TimeData struct
 
+TimeData is passed to you as a paramter when using either PromiseTimer.WaitUntil or PromiseTimer.WaitWhile. It contains the following public fields:
+
+    elapsedTime - The amount of time that has elapsed since the pending promise started running
+    deltaTime - The amount of time since the last time the pending promise was updated.
+    elapsedUpdates - The amount of times that PromiseTimer.Update() has been called since the pending promise started running
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -517,9 +517,9 @@ WaitFor is exactly the same as WaitUntil except that it resolves when its predic
 
 TimeData is passed to you as a paramter when using either PromiseTimer.WaitUntil or PromiseTimer.WaitWhile. It contains the following public fields:
 
-    elapsedTime - The amount of time that has elapsed since the pending promise started running
-    deltaTime - The amount of time since the last time the pending promise was updated.
-    elapsedUpdates - The amount of times that PromiseTimer.Update() has been called since the pending promise started running
+- elapsedTime - The amount of time that has elapsed since the pending promise started running
+- deltaTime - The amount of time since the last time the pending promise was updated.
+- elapsedUpdates - The amount of times that PromiseTimer.Update() has been called since the pending promise started running
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -517,9 +517,12 @@ WaitFor is exactly the same as WaitUntil except that it resolves when its predic
 
 TimeData is passed to you as a paramter when using either PromiseTimer.WaitUntil or PromiseTimer.WaitWhile. It contains the following public fields:
 
-- elapsedTime - The amount of time that has elapsed since the pending promise started running
-- deltaTime - The amount of time since the last time the pending promise was updated.
-- elapsedUpdates - The amount of times that PromiseTimer.Update() has been called since the pending promise started running
+- elapsedTime
+    - The amount of time that has elapsed since the pending promise started running
+- deltaTime
+    - The amount of time since the last time the pending promise was updated.
+- elapsedUpdates
+    - The amount of times that PromiseTimer.Update() has been called since the pending promise started running
 
 ## Examples
 

--- a/Tests/PromiseTimerTests.cs
+++ b/Tests/PromiseTimerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,6 +8,27 @@ namespace RSG.Tests
 {
     public class PromiseTimerTests
     {
+        [Fact]
+        public void wait_until_elapsedUpdates_resolves_when_predicate_is_true()
+        {
+            var testObject = new PromiseTimer();
+
+            var testFrame = 3;
+            var hasResolved = false;
+
+            testObject.WaitUntil((timeData) => timeData.elapsedUpdates == testFrame)
+                .Then(() => hasResolved = true)
+                .Done();
+
+            Assert.False(hasResolved);
+
+            testObject.Update(1);
+            testObject.Update(2);
+            testObject.Update(3);
+
+            Assert.True(hasResolved);
+        }
+
         [Fact]
         public void wait_for_doesnt_resolve_before_specified_time()
         {


### PR DESCRIPTION
Based off the conversion in pull request #45. the elapsedUpdates works exactly like elapsedTime, just counts the amount of times Update was called on the promise instead