### PR TITLE
Support returning values from Catch handler

### DIFF
--- a/EnumerableExt.cs
+++ b/EnumerableExt.cs
@@ -8,21 +8,6 @@ namespace RSG.Promises
     /// </summary>
     public static class EnumerableExt
     {
-        public static IEnumerable<T> Empty<T>()
-        {
-            return new T[0];
-        }
-
-        public static IEnumerable<T> LazyEach<T>(this IEnumerable<T> source, Action<T> fn)
-        {
-            foreach (var item in source)
-            {
-                fn.Invoke(item);
-
-                yield return item;
-            }
-        }
-
         public static void Each<T>(this IEnumerable<T> source, Action<T> fn)
         {
             foreach (var item in source)

--- a/Examples/Example3/Program.cs
+++ b/Examples/Example3/Program.cs
@@ -31,12 +31,6 @@ namespace Example
                         .Find(html)
                         .Select(link => link.Href)
                         .ToArray();
-                })            
-                .Catch(exception =>     // Catch any errors that happen during download or transform.
-                {
-                    Console.WriteLine("Async operation errorred.");
-                    Console.WriteLine(exception);
-                    running = false;
                 })
                 .Then(links =>          // Display the links that were extracted.
                 {
@@ -45,6 +39,12 @@ namespace Example
                     {
                         Console.WriteLine(link);
                     }
+                    running = false;
+                })            
+                .Catch(exception =>     // Catch any errors that happen during download or transform.
+                {
+                    Console.WriteLine("Async operation errorred.");
+                    Console.WriteLine(exception);
                     running = false;
                 })
                 .Done();

--- a/Examples/Example4/Program.cs
+++ b/Examples/Example4/Program.cs
@@ -34,16 +34,16 @@ namespace Example4
                         .First();              // Grab the 6th link.
                 })
                 .Then(firstLink => Download(firstLink)) // Follow the first link and download it.
-                .Catch(exception =>                     // Catch any errors that happen during download or transform.
-                {
-                    Console.WriteLine("Async operation errorred.");
-                    Console.WriteLine(exception);
-                    running = false;
-                })
                 .Then(html =>          // Display html from the link that was followed.
                 {
                     Console.WriteLine("Async operation completed.");
                     Console.WriteLine(html.Substring(0, 250) + "...");
+                    running = false;
+                })
+                .Catch(exception =>                     // Catch any errors that happen during download or transform.
+                {
+                    Console.WriteLine("Async operation errorred.");
+                    Console.WriteLine(exception);
                     running = false;
                 })
                 .Done();

--- a/Examples/Example5/Program.cs
+++ b/Examples/Example5/Program.cs
@@ -38,12 +38,6 @@ namespace Example4
                             link => Download(link)                  // Download each link.
                         )
                 ))
-                .Catch(exception =>     // Catch any errors that happen during download or transform.
-                {
-                    Console.WriteLine("Async operation errorred.");
-                    Console.WriteLine(exception);
-                    running = false;
-                })
                 .Then(htmls =>          // Display html from the link that was followed.
                 {
                     Console.WriteLine("Async operation completed.");
@@ -57,6 +51,12 @@ namespace Example4
                     Console.WriteLine("---------------");
                     Console.WriteLine("Downloaded " + htmls.Count() + " pages");
 
+                    running = false;
+                })
+                .Catch(exception =>     // Catch any errors that happen during download or transform.
+                {
+                    Console.WriteLine("Async operation errorred.");
+                    Console.WriteLine(exception);
                     running = false;
                 })
                 .Done();

--- a/Promise.cs
+++ b/Promise.cs
@@ -47,6 +47,11 @@ namespace RSG
         IPromise<PromisedT> Catch(Action<Exception> onRejected);
 
         /// <summary>
+        /// Handle errors for the promise. 
+        /// </summary>
+        IPromise<PromisedT> Catch(Func<Exception, PromisedT> onRejected);
+
+        /// <summary>
         /// Add a resolved callback that chains a value promise (optionally converting to a different value type).
         /// </summary>
         IPromise<ConvertedT> Then<ConvertedT>(Func<PromisedT, IPromise<ConvertedT>> onResolved);
@@ -457,6 +462,36 @@ namespace RSG
                     resultPromise.Resolve(default(PromisedT));
                 }
                 catch(Exception cbEx)
+                {
+                    resultPromise.Reject(cbEx);
+                }
+            };
+
+            ActionHandlers(resultPromise, resolveHandler, rejectHandler);
+
+            return resultPromise;
+        }
+
+        /// <summary>
+        /// Handle errors for the promise.
+        /// </summary>
+        public IPromise<PromisedT> Catch(Func<Exception, PromisedT> onRejected)
+        {
+            var resultPromise = new Promise<PromisedT>();
+            resultPromise.WithName(Name);
+
+            Action<PromisedT> resolveHandler = v =>
+            {
+                resultPromise.Resolve(v);
+            };
+
+            Action<Exception> rejectHandler = ex =>
+            {
+                try
+                {
+                    resultPromise.Resolve(onRejected(ex));
+                }
+                catch (Exception cbEx)
                 {
                     resultPromise.Reject(cbEx);
                 }

--- a/Promise.cs
+++ b/Promise.cs
@@ -93,13 +93,6 @@ namespace RSG
         IPromise<ConvertedT> Then<ConvertedT>(Func<PromisedT, ConvertedT> transform);
 
         /// <summary>
-        /// Return a new promise with a different value.
-        /// May also change the type of the value.
-        /// </summary>
-        [Obsolete("Use Then instead")]
-        IPromise<ConvertedT> Transform<ConvertedT>(Func<PromisedT, ConvertedT> transform);
-
-        /// <summary>
         /// Chain an enumerable of promises, all of which must resolve.
         /// Returns a promise for a collection of the resolved results.
         /// The resulting promise is resolved when all of the promises have resolved.
@@ -654,17 +647,6 @@ namespace RSG
         /// May also change the type of the value.
         /// </summary>
         public IPromise<ConvertedT> Then<ConvertedT>(Func<PromisedT, ConvertedT> transform)
-        {
-//            Argument.NotNull(() => transform);
-            return Then(value => Promise<ConvertedT>.Resolved(transform(value)));
-        }
-
-        /// <summary>
-        /// Return a new promise with a different value.
-        /// May also change the type of the value.
-        /// </summary>
-        [Obsolete("Use Then instead")]
-        public IPromise<ConvertedT> Transform<ConvertedT>(Func<PromisedT, ConvertedT> transform)
         {
 //            Argument.NotNull(() => transform);
             return Then(value => Promise<ConvertedT>.Resolved(transform(value)));

--- a/Promise.cs
+++ b/Promise.cs
@@ -441,8 +441,6 @@ namespace RSG
         /// </summary>
         public IPromise<PromisedT> Catch(Action<Exception> onRejected)
         {
-//            Argument.NotNull(() => onRejected);
-
             var resultPromise = new Promise<PromisedT>();
             resultPromise.WithName(Name);
 
@@ -453,9 +451,15 @@ namespace RSG
 
             Action<Exception> rejectHandler = ex =>
             {
-                onRejected(ex);
-
-                resultPromise.Reject(ex);
+                try
+                {
+                    onRejected(ex);
+                    resultPromise.Resolve(default(PromisedT));
+                }
+                catch(Exception cbEx)
+                {
+                    resultPromise.Reject(cbEx);
+                }
             };
 
             ActionHandlers(resultPromise, resolveHandler, rejectHandler);

--- a/Promise.cs
+++ b/Promise.cs
@@ -730,7 +730,7 @@ namespace RSG
             var promisesArray = promises.ToArray();
             if (promisesArray.Length == 0)
             {
-                return Promise<IEnumerable<PromisedT>>.Resolved(EnumerableExt.Empty<PromisedT>());
+                return Promise<IEnumerable<PromisedT>>.Resolved(Enumerable.Empty<PromisedT>());
             }
 
             var remainingCount = promisesArray.Length;

--- a/Promise.cs
+++ b/Promise.cs
@@ -1,4 +1,4 @@
-﻿using RSG.Promises;
+using RSG.Promises;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -449,10 +449,7 @@ namespace RSG
             var resultPromise = new Promise();
             resultPromise.WithName(Name);
 
-            Action<PromisedT> resolveHandler = _ =>
-            {
-                resultPromise.Resolve();
-            };
+            Action<PromisedT> resolveHandler = _ => resultPromise.Resolve();
 
             Action<Exception> rejectHandler = ex =>
             {
@@ -480,10 +477,7 @@ namespace RSG
             var resultPromise = new Promise<PromisedT>();
             resultPromise.WithName(Name);
 
-            Action<PromisedT> resolveHandler = v =>
-            {
-                resultPromise.Resolve(v);
-            };
+            Action<PromisedT> resolveHandler = v => resultPromise.Resolve(v);
 
             Action<Exception> rejectHandler = ex =>
             {

--- a/PromiseHelpers.cs
+++ b/PromiseHelpers.cs
@@ -19,8 +19,7 @@ namespace RSG
             var promise = new Promise<Tuple<T1, T2>>();
 
             p1
-                .Catch(e => promise.Reject(e))
-                .Done(val => 
+                .Then(val => 
                 {
                     val1 = val;
                     numUnresolved--;
@@ -28,11 +27,12 @@ namespace RSG
                     {
                         promise.Resolve(Tuple.Create(val1, val2));
                     }
-                });
+                })
+                .Catch(e => promise.Reject(e))
+                .Done();
 
             p2
-                .Catch(e => promise.Reject(e))
-                .Done(val => 
+                .Then(val => 
                 {
                     val2 = val;
                     numUnresolved--;
@@ -40,7 +40,9 @@ namespace RSG
                     {
                         promise.Resolve(Tuple.Create(val1, val2));
                     }
-                });
+                })
+                .Catch(e => promise.Reject(e))
+                .Done();
 
             return promise;
         }

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -1,4 +1,4 @@
-﻿using RSG.Promises;
+using RSG.Promises;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -511,9 +511,7 @@ namespace RSG
         /// </summary>
         public void Done()
         {
-            Catch(ex =>
-                Promise.PropagateUnhandledException(this, ex)
-            );
+            Catch(ex => PropagateUnhandledException(this, ex));
         }
 
         /// <summary>
@@ -542,9 +540,15 @@ namespace RSG
 
             Action<Exception> rejectHandler = ex =>
             {
-                onRejected(ex);
-
-                resultPromise.Reject(ex);
+                try
+                {
+                    onRejected(ex);
+                    resultPromise.Resolve();
+                }
+                catch (Exception callbackException)
+                {
+                    resultPromise.Reject(callbackException);
+                }
             };
 
             ActionHandlers(resultPromise, resolveHandler, rejectHandler);
@@ -806,7 +810,7 @@ namespace RSG
         public static IPromise Sequence(IEnumerable<Func<IPromise>> fns)
         {
             return fns.Aggregate(
-                Promise.Resolved(),
+                Resolved(),
                 (prevPromise, fn) =>
                 {
                     return prevPromise.Then(() => fn());
@@ -820,7 +824,7 @@ namespace RSG
         /// </summary>
         public IPromise ThenRace(Func<IEnumerable<IPromise>> chain)
         {
-            return Then(() => Promise.Race(chain()));
+            return Then(() => Race(chain()));
         }
 
         /// <summary>

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -533,10 +533,7 @@ namespace RSG
             var resultPromise = new Promise();
             resultPromise.WithName(Name);
 
-            Action resolveHandler = () =>
-            {
-                resultPromise.Resolve();
-            };
+            Action resolveHandler = () => resultPromise.Resolve();
 
             Action<Exception> rejectHandler = ex =>
             {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ There is another way to create a promise that replicates the JavaScript conventi
 The simplest usage is to register a completion handler to be invoked on completion of the async op:
 
     Download("http://www.google.com")
-        .Done(html =>
+        .Then(html =>
             Console.WriteLine(html)
         );
 
@@ -172,11 +172,11 @@ This snippet downloads the front page from Google and prints it to the console.
 For all but the most trivial applications you will also want to register an error hander:
 
     Download("http://www.google.com")
+        .Then(html =>
+            Console.WriteLine(html)
+        )
         .Catch(exception =>
             Console.WriteLine("An exception occured while downloading!")
-        )
-        .Done(html =>
-            Console.WriteLine(html)
         );
 
 The chain of processing for a promise ends as soon as an error/exception occurs. In this case when an error occurs the *Catch* handler would be called, but not the *Done* handler. If there is no error, then only *Done* is called.
@@ -189,11 +189,11 @@ Multiple async operations can be chained one after the other using *Then*:
         .Then(html =>
             return Download(ExtractFirstLink(html)) // Extract the first link and download it. 
         )
+        .Then(firstLinkHtml =>
+            Console.WriteLine(firstLinkHtml)
+        )
         .Catch(exception =>
             Console.WriteLine("An exception occured while downloading!")
-        )
-        .Done(firstLinkHtml =>
-            Console.WriteLine(firstLinkHtml)
         );
  
 Here we are chaining another download onto the end of the first download. The first link in the html is extracted and we then download that. *Then* expects the return value to be another promise. The chained promise can have a different *result type*.
@@ -206,7 +206,7 @@ Sometimes you will want to simply transform or modify the resulting value withou
         .Then(html =>
             return ExtractAllLinks(html))   // Extract all links and return an array of strings.  
         )
-        .Done(links =>                      // The input here is an array of strings.
+        .Then(links =>                      // The input here is an array of strings.
             foreach (var link in links)
             {
                 Console.WriteLine(link);

--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@ If you are interested in using promises for game development and Unity please se
 
 ## Recent Updates
 
-- 8 March 2015
+- v2.0 (4 December 2017)
+    - *Then* functions chained after a *Catch* are now run after the exception is handled rather than being terminated
+    - *Catch* can return a value which will be passed into the next *Then*
+    - The *onResolved* callback of *Then* can now also return a value which is passed to the next promise in the same way
+    - Added *elapsedUpdates* property to the TimeData struct used by PromiseTimer
+- v1.3 (28 October 2017)
+    - Added Cancel method to PromiseTimer
+    - Implemented an overload of Promise.All that works on Tuples of multiple types
+    - Implemented Finally method
+    - Removed dependency on RSG.Toolkit
+- v1.2 (8 March 2015)
     - *Transform* function has been renamed to *Then* (another overload of *Then*).
     
 ## Projects using this library

--- a/Tests/A+ Spec/2.2.cs
+++ b/Tests/A+ Spec/2.2.cs
@@ -373,7 +373,7 @@ namespace RSG.Tests.A__Spec
 
                     new Promise<object>((res, rej) => rej(new Exception()))
                         .Catch(_ => {})
-                        .Then(_ => callbackInvoked = true);
+                        .Then(() => callbackInvoked = true);
 
                     Assert.True(callbackInvoked);
                 }

--- a/Tests/A+ Spec/2.2.cs
+++ b/Tests/A+ Spec/2.2.cs
@@ -366,6 +366,18 @@ namespace RSG.Tests.A__Spec
                     Assert.Equal(1, promise1ThenHandler);
                     Assert.Equal(1, promise2ThenHandler);
                 }
+
+                [Fact]
+                public void _when_promise1_is_rejected_with_no_value()
+                {
+                    var callbackInvoked = false;
+
+                    new Promise<object>((res, rej) => rej(new Exception()))
+                        .Catch(ex => {})
+                        .Then(_ => callbackInvoked = true);
+
+                    Assert.True(callbackInvoked);
+                }
             }
 
             // 2.2.7.2

--- a/Tests/A+ Spec/2.2.cs
+++ b/Tests/A+ Spec/2.2.cs
@@ -331,7 +331,6 @@ namespace RSG.Tests.A__Spec
         {
 
             // 2.2.7.1
-            // todo: Catch handler needs to be able to return a value.
             public class _If_either_onFulfilled_or_onRejected_returns_a_value_x_fulfill_promise_with_x
             {
                 [Fact]
@@ -373,10 +372,23 @@ namespace RSG.Tests.A__Spec
                     var callbackInvoked = false;
 
                     new Promise<object>((res, rej) => rej(new Exception()))
-                        .Catch(ex => {})
+                        .Catch(_ => {})
                         .Then(_ => callbackInvoked = true);
 
                     Assert.True(callbackInvoked);
+                }
+
+                [Fact]
+                public void _when_promise1_is_rejected_with_value()
+                {
+                    var expectedValue = "Value returned from Catch";
+                    var actualValue = string.Empty;
+
+                    new Promise<string>((res, rej) => rej(new Exception()))
+                        .Catch(_ => expectedValue)
+                        .Then(val => actualValue = val);
+
+                    Assert.Equal(expectedValue, actualValue);
                 }
             }
 

--- a/Tests/A+ Spec/2.2.cs
+++ b/Tests/A+ Spec/2.2.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -389,6 +389,18 @@ namespace RSG.Tests.A__Spec
                         .Then(val => actualValue = val);
 
                     Assert.Equal(expectedValue, actualValue);
+                }
+
+                [Fact]
+                public void _when_non_generic_promise1_is_rejected()
+                {
+                    var callbackInvoked = false;
+
+                    new Promise((res, rej) => rej(new Exception()))
+                        .Catch(_ => {})
+                        .Then(() => callbackInvoked = true);
+
+                    Assert.True(callbackInvoked);
                 }
             }
 

--- a/Tests/A+ Spec/2.2.cs
+++ b/Tests/A+ Spec/2.2.cs
@@ -367,7 +367,7 @@ namespace RSG.Tests.A__Spec
                 }
 
                 [Fact]
-                public void _when_promise1_is_rejected_with_no_value()
+                public void _when_promise1_is_rejected_with_no_value_in_catch()
                 {
                     var callbackInvoked = false;
 
@@ -378,14 +378,48 @@ namespace RSG.Tests.A__Spec
                     Assert.True(callbackInvoked);
                 }
 
+                public void _when_promise1_is_rejected_with_no_value_in_then()
+                {
+                    var callbackInvoked = false;
+                    var resolveHandlerInvoked = false;
+                    var rejectHandlerInvoked = false;
+
+                    new Promise((res, rej) => rej(new Exception()))
+                        .Then(
+                            () => { resolveHandlerInvoked = true; }, 
+                            ex => { rejectHandlerInvoked = true; }
+                        )
+                        .Then(() => callbackInvoked = true);
+
+                    Assert.True(callbackInvoked);
+                    Assert.False(resolveHandlerInvoked);
+                    Assert.True(rejectHandlerInvoked);
+                }
+
                 [Fact]
-                public void _when_promise1_is_rejected_with_value()
+                public void _when_promise1_is_rejected_with_value_in_catch()
                 {
                     var expectedValue = "Value returned from Catch";
                     var actualValue = string.Empty;
 
                     new Promise<string>((res, rej) => rej(new Exception()))
                         .Catch(_ => expectedValue)
+                        .Then(val => actualValue = val);
+
+                    Assert.Equal(expectedValue, actualValue);
+                }
+
+                [Fact]
+                public void _when_promise1_is_rejected_with_value_in_then()
+                {
+                    var expectedValue = "Value returned from reject handler";
+                    var actualValue = string.Empty;
+
+                    new Promise<string>((res, rej) => rej(new Exception()))
+                        .Then(
+                            _ => Promise<string>.Resolved(string.Empty),
+                            _ => Promise<string>.Resolved(expectedValue)
+                        )
                         .Then(val => actualValue = val);
 
                     Assert.Equal(expectedValue, actualValue);

--- a/Tests/PromiseTests.cs
+++ b/Tests/PromiseTests.cs
@@ -1288,5 +1288,37 @@ namespace RSG.Tests
 
             Assert.Equal(2, callback);
         }
+
+        [Fact]
+        public void exception_in_reject_callback_is_caught_by_chained_catch()
+        {
+            var expectedException = new Exception("Expected");
+            Exception actualException = null;
+
+            new Promise<object>((res, rej) => rej(new Exception()))
+                .Then(
+                    _ => Promise<object>.Resolved(null),
+                    _ => throw expectedException
+                )
+                .Catch(ex => actualException = ex);
+
+            Assert.Equal(expectedException, actualException);
+        }
+
+        [Fact]
+        public void rejected_reject_callback_is_caught_by_chained_catch()
+        {
+            var expectedException = new Exception("Expected");
+            Exception actualException = null;
+
+            new Promise<object>((res, rej) => rej(new Exception()))
+                .Then(
+                    _ => Promise<object>.Resolved(null),
+                    _ => Promise<object>.Rejected(expectedException)
+                )
+                .Catch(ex => actualException = ex);
+
+            Assert.Equal(expectedException, actualException);
+        }
     }
 }

--- a/Tests/PromiseTests.cs
+++ b/Tests/PromiseTests.cs
@@ -598,7 +598,7 @@ namespace RSG.Tests
         [Fact]
         public void combined_promise_is_resolved_if_there_are_no_promises()
         {
-            var all = Promise<int>.All(EnumerableExt.Empty<IPromise<int>>());
+            var all = Promise<int>.All(Enumerable.Empty<IPromise<int>>());
 
             var completed = 0;
 

--- a/Tests/PromiseTests.cs
+++ b/Tests/PromiseTests.cs
@@ -1040,7 +1040,7 @@ namespace RSG.Tests
 
                 promise.Resolve(5);
 
-                Assert.Equal(1, eventRaised);
+                Assert.Equal(0, eventRaised);
             }
             finally
             {

--- a/Tests/Promise_NonGeneric_Tests.cs
+++ b/Tests/Promise_NonGeneric_Tests.cs
@@ -727,15 +727,16 @@ namespace RSG.Tests
             var ex = new Exception();
 
             Promise
-                .Sequence(() => 
+                .Sequence(() =>
                 {
                     throw ex;
                 })
-                .Catch(e => {
+                .Then(() => ++completed)
+                .Catch(e =>
+                {
                     Assert.Equal(ex, e);
                     ++errored;
-                })
-                .Then(() => ++completed);
+                });
 
             Assert.Equal(1, errored);
             Assert.Equal(0, completed);
@@ -917,7 +918,7 @@ namespace RSG.Tests
 
                 promise.Resolve();
 
-                Assert.Equal(1, eventRaised);
+                Assert.Equal(0, eventRaised);
             }
             finally
             {

--- a/Tests/Promise_NonGeneric_Tests.cs
+++ b/Tests/Promise_NonGeneric_Tests.cs
@@ -415,7 +415,7 @@ namespace RSG.Tests
         [Fact]
         public void combined_promise_is_resolved_if_there_are_no_promises()
         {
-            var all = Promise.All(EnumerableExt.Empty<IPromise>());
+            var all = Promise.All(Enumerable.Empty<IPromise>());
 
             var completed = 0;
 


### PR DESCRIPTION
As per the [Promises/A+ spec](https://promisesaplus.com/#point-41), `.Catch` handlers should be able to have a `.Then` chained after them. Any value returned by the `.Catch` callback should also be passed to the following `.Then`.

Implemented based on the suggestion from @philippevk's suggestion in issue #51, with some minor modifications and tests. 

I think being able to chain a `.Then` after a `.Catch` also makes `.Finally` effectively obsolete, since regular `.Then` has the same functionality now. Transform also is not part of the A+ spec or ES6 promises so perhaps we should mark it as obsolete after this is merged, like we did with `.Transform` after the regular `.Then` method was upgraded to be able to transform promises?