### PR TITLE
tc39 spec conformance

### DIFF
--- a/Promise.cs
+++ b/Promise.cs
@@ -843,7 +843,8 @@ namespace RSG
             return promise;
         }
 
-        public IPromise<PromisedT> Finally(Action onComplete) {
+        public IPromise<PromisedT> Finally(Action onComplete)
+        {
             Promise<PromisedT> promise = new Promise<PromisedT>();
             promise.WithName(Name);
 

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -908,7 +908,8 @@ namespace RSG
             return promise;
         }
 
-        public IPromise Finally(Action onComplete) {
+        public IPromise Finally(Action onComplete)
+        {
             Promise promise = new Promise();
             promise.WithName(Name);
 

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -116,18 +116,22 @@ namespace RSG
 
         /// <summary> 
         /// Add a finally callback. 
-        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error. 
+        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+        /// The returned promise will be resolved or rejected, as per the preceding promise.
         /// </summary> 
         IPromise Finally(Action onComplete);
 
         /// <summary>
         /// Add a finally callback that chains a non-value promise.
+        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+        /// The state of the returning promise will be based on the new non-value promise, not the preceding (rejected or resolved) promise.
         /// </summary>
         IPromise Finally(Func<IPromise> onResolved);
 
         /// <summary> 
-        /// Add a finally callback. 
-        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error. 
+        /// Add a finally callback that chains a value promise (optionally converting to a different value type).
+        /// Finally callbacks will always be called, even if any preceding promise is rejected, or encounters an error.
+        /// The state of the returning promise will be based on the new value promise, not the preceding (rejected or resolved) promise.
         /// </summary> 
         IPromise<ConvertedT> Finally<ConvertedT>(Func<IPromise<ConvertedT>> onComplete);
     }
@@ -904,15 +908,21 @@ namespace RSG
             return promise;
         }
 
-        public IPromise Finally(Action onComplete)
-        {
+        public IPromise Finally(Action onComplete) {
             Promise promise = new Promise();
             promise.WithName(Name);
 
             this.Then(() => { promise.Resolve(); });
-            this.Catch((e) => { promise.Resolve(); });
+            this.Catch((e) => {
+                try {
+                    onComplete();
+                    promise.Reject(e);
+                } catch (Exception ne) {
+                    promise.Reject(ne);
+                }
+            });
 
-            return promise.Then(onComplete);
+            return promise.Then(() => onComplete());
         }
 
         public IPromise Finally(Func<IPromise> onComplete)

--- a/Tests/Promise_NonGeneric_Tests.cs
+++ b/Tests/Promise_NonGeneric_Tests.cs
@@ -1221,7 +1221,7 @@ namespace RSG.Tests
                 ++callback;
                 return Promise<string>.Resolved("foo");
             })
-            .Then((s) => {
+            .Then((x) => {
                 Assert.Equal(expectedValue, x);
                 ++callback;
             });

--- a/Tests/Promise_NonGeneric_Tests.cs
+++ b/Tests/Promise_NonGeneric_Tests.cs
@@ -1174,7 +1174,7 @@ namespace RSG.Tests
         }
 
         [Fact]
-        public void rejected_chain_continues_after_finally()
+        public void rejected_chain_rejects_after_finally()
         {
             var promise = new Promise();
             var callback = 0;
@@ -1183,8 +1183,123 @@ namespace RSG.Tests
             {
                 ++callback;
             })
-            .Then(() =>
+            .Catch(_ =>
             {
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        public void rejected_chain_continues_after_finally_returning_non_value_promise() {
+            var promise = new Promise();
+            var callback = 0;
+
+            promise.Finally(() => {
+                ++callback;
+                return Promise.Resolved();
+            })
+            .Then(() => {
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        public void rejected_chain_continues_after_finally_returning_value_promise() {
+            var promise = new Promise();
+            var callback = 0;
+            var expectedValue = "foo";
+
+            promise.Finally(() => {
+                ++callback;
+                return Promise<string>.Resolved("foo");
+            })
+            .Then((s) => {
+                Assert.Equal(expectedValue, x);
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        //tc39 note: "a throw (or returning a rejected promise) in the finally callback will reject the new promise with that rejection reason."
+        public void exception_in_finally_callback_is_caught_by_chained_catch()
+        {
+            //NOTE: Also tests that the new exception is passed thru promise chain
+
+            var promise = new Promise();
+            var callback = 0;
+            var expectedException = new Exception("Expected");
+
+            // NOTE: typecast needed to call Finally(Action), and not Finally(Func<IPromise>)
+            promise.Finally((Action)(() =>
+            {
+                ++callback;
+                throw expectedException;
+            }))
+            .Catch(ex =>
+            {
+                Assert.Equal(expectedException, ex);
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        public void exception_in_finally_callback_returning_non_value_promise_is_caught_by_chained_catch()
+        {
+            //NOTE: Also tests that the new exception is passed thru promise chain
+
+            var promise = new Promise();
+            var callback = 0;
+            var expectedException = new Exception("Expected");
+
+            promise.Finally(new Func<IPromise>(() =>
+            {
+                ++callback;
+                throw expectedException;
+            }))
+            .Catch(ex =>
+            {
+                Assert.Equal(expectedException, ex);
+                ++callback;
+            });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(2, callback);
+        }
+
+        [Fact]
+        public void exception_in_finally_callback_returning_value_promise_is_caught_by_chained_catch()
+        {
+            //NOTE: Also tests that the new exception is passed thru promise chain
+
+            var promise = new Promise();
+            var callback = 0;
+            var expectedException = new Exception("Expected");
+
+            promise.Finally(new Func<IPromise<int>>(() =>
+            {
+                ++callback;
+                throw expectedException;
+            }))
+            .Catch(ex =>
+            {
+                Assert.Equal(expectedException, ex);
                 ++callback;
             });
 
@@ -1207,8 +1322,8 @@ namespace RSG.Tests
             })
             .Then((x) =>
             {
-                ++callback;
                 Assert.Equal(expectedValue, x);
+                ++callback;
             });
 
             promise.Resolve();


### PR DESCRIPTION
Changed Finally implementation to conform to spec tc39:
	When calling Finally that accepts an Action, resolved values are passed through the promise chain
	When calling Finally that accepts an Action, rejected promise exceptions are passed through the promise chain
	When an exception is thrown in Finally, the resulting promise rejects with the new exception (even if the previous promise was rejected)

Added tests to test this behavior and other behavior of tc39, e.g. throwing exceptions in finally

Scope Creep:
    Fixed a compiler error in exception_in_reject_callback_is_caught_by_chained_catch
    Fixed a handful of tests that had asserts in the promise callbacks after the counter that was used to verify success/failure