### PR TITLE
Added support for progress reporting.

### DIFF
--- a/Promise.cs
+++ b/Promise.cs
@@ -200,6 +200,11 @@ namespace RSG
         /// Resolve the promise with a particular value.
         /// </summary>
         void Resolve(PromisedT value);
+
+        /// <summary>
+        /// Report progress in a promise.
+        /// </summary>
+        void ReportProgress(float progress);
     }
 
     /// <summary>

--- a/Promise.cs
+++ b/Promise.cs
@@ -973,27 +973,13 @@ namespace RSG
             return promise.Then(onComplete);
         }
 
-        public IPromise<PromisedT> Progress(Action<float> onProgress)
+        public IPromise Progress(Action<float> onProgress)
         {
-            var resultPromise = new Promise<PromisedT>();
-            resultPromise.WithName(Name);
-
-            this.Then((x) => { resultPromise.Resolve(x); });
-            this.Catch((e) => { resultPromise.Reject(e); });
-
-            Action<float> progressHandler = v =>
+            if (onProgress != null)
             {
-                if (onProgress != null)
-                {
-                    onProgress(v);
-                }
-
-                resultPromise.ReportProgress(v);
-            };
-
-            ProgressHandlers(resultPromise, progressHandler);
-
-            return resultPromise;
+                ProgressHandlers(this, onProgress);
+            }
+            return this;
         }
 
         public IPromise<PromisedT> Progress(Func<float, float> onProgress)

--- a/Promise.cs
+++ b/Promise.cs
@@ -858,6 +858,11 @@ namespace RSG
             promisesArray.Each((promise, index) =>
             {
                 promise
+                    .Progress(v =>
+                    {
+                        progress[index] = v;
+                        resultPromise.ReportProgress(progress.Average());
+                    })
                     .Then(result =>
                     {
                         results[index] = result;
@@ -877,11 +882,6 @@ namespace RSG
                             resultPromise.Reject(ex);
                         }
                         return default(PromisedT);
-                    })
-                    .Progress(v =>
-                    {
-                        progress[index] = v;
-                        resultPromise.ReportProgress(progress.Average());
                     })
                     .Done();
             });
@@ -939,6 +939,11 @@ namespace RSG
             promisesArray.Each((promise, index) =>
             {
                 promise
+                    .Progress(v =>
+                    {
+                        progress[index] = v;
+                        resultPromise.ReportProgress(progress.Max());
+                    })
                     .Then(result =>
                     {
                         if (resultPromise.CurState == PromiseState.Pending)
@@ -953,11 +958,6 @@ namespace RSG
                             // If a promise errorred and the result promise is still pending, reject it.
                             resultPromise.Reject(ex);
                         }
-                    })
-                    .Progress(v =>
-                    {
-                        progress[index] = v;
-                        resultPromise.ReportProgress(progress.Max());
                     })
                     .Done();
             });

--- a/Promise.cs
+++ b/Promise.cs
@@ -1,4 +1,4 @@
-﻿using RSG.Promises;
+using RSG.Promises;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -865,6 +865,7 @@ namespace RSG
                     })
                     .Then(result =>
                     {
+                        progress[index] = 1f;
                         results[index] = result;
 
                         --remainingCount;

--- a/Promise.cs
+++ b/Promise.cs
@@ -973,7 +973,7 @@ namespace RSG
             return promise.Then(onComplete);
         }
 
-        public IPromise Progress(Action<float> onProgress)
+        public IPromise<PromisedT> Progress(Action<float> onProgress)
         {
             if (onProgress != null)
             {

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -919,6 +919,11 @@ namespace RSG
             promisesArray.Each((promise, index) =>
             {
                 promise
+                    .Progress(v =>
+                    {
+                        progress[index] = v;
+                        resultPromise.ReportProgress(progress.Average());
+                    })
                     .Catch(ex =>
                     {
                         if (resultPromise.CurState == PromiseState.Pending)
@@ -935,11 +940,6 @@ namespace RSG
                             // This will never happen if any of the promises errorred.
                             resultPromise.Resolve();
                         }
-                    })
-                    .Progress(v =>
-                    {
-                        progress[index] = v;
-                        resultPromise.ReportProgress(progress.Average());
                     })
                     .Done();
             });
@@ -1030,6 +1030,11 @@ namespace RSG
             promisesArray.Each((promise, index) =>
             {
                 promise
+                    .Progress(v =>
+                    {
+                        progress[index] = v;
+                        resultPromise.ReportProgress(progress.Max());
+                    })
                     .Catch(ex =>
                     {
                         if (resultPromise.CurState == PromiseState.Pending)
@@ -1044,11 +1049,6 @@ namespace RSG
                         {
                             resultPromise.Resolve();
                         }
-                    })
-                    .Progress(v =>
-                    {
-                        progress[index] = v;
-                        resultPromise.ReportProgress(progress.Max());
                     })
                     .Done();
             });

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -1072,25 +1072,11 @@ namespace RSG
 
         public IPromise Progress(Action<float> onProgress)
         {
-            var resultPromise = new Promise();
-            resultPromise.WithName(Name);
-
-            this.Then(() => { resultPromise.Resolve(); });
-            this.Catch((e) => { resultPromise.Reject(e); });
-
-            Action<float> progressHandler = v =>
+            if (onProgress != null)
             {
-                if (onProgress != null)
-                {
-                    onProgress(v);
-                }
-
-                resultPromise.ReportProgress(v);
-            };
-
-            ProgressHandlers(resultPromise, progressHandler);
-
-            return resultPromise;
+                ProgressHandlers(this, onProgress);
+            }
+            return this;
         }
 
         public IPromise Progress(Func<float, float> onProgress)

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -176,6 +176,11 @@ namespace RSG
         /// Resolve the promise with a particular value.
         /// </summary>
         void Resolve();
+
+        /// <summary>
+        /// Report progress in a promise.
+        /// </summary>
+        void ReportProgress(float progress);
     }
 
     /// <summary>

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -1,4 +1,4 @@
-﻿using RSG.Promises;
+using RSG.Promises;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -934,6 +934,8 @@ namespace RSG
                     })
                     .Then(() =>
                     {
+                        progress[index] = 1f;
+
                         --remainingCount;
                         if (remainingCount <= 0)
                         {

--- a/Tests/Promise.Tests.csproj
+++ b/Tests/Promise.Tests.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="A+ Spec\2.2.cs" />
     <Compile Include="PromiseProgressTests.cs" />
+    <Compile Include="Promise_NonGeneric_ProgressTests.cs" />
     <Compile Include="PromiseTests.cs" />
     <Compile Include="PromiseTimerTests.cs" />
     <Compile Include="Promise_NonGeneric_Tests.cs" />

--- a/Tests/Promise.Tests.csproj
+++ b/Tests/Promise.Tests.csproj
@@ -47,12 +47,12 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="A+ Spec\2.2.cs" />
+    <Compile Include="PromiseProgressTests.cs" />
     <Compile Include="PromiseTests.cs" />
     <Compile Include="PromiseTimerTests.cs" />
     <Compile Include="Promise_NonGeneric_Tests.cs" />

--- a/Tests/PromiseProgressTests.cs
+++ b/Tests/PromiseProgressTests.cs
@@ -61,7 +61,7 @@ namespace RSG.Tests
         }
 
         [Fact]
-        public void can_do_weighted_average()
+        public void can_do_progress_weighted_average()
         {
             var promiseA = new Promise();
             var promiseB = new Promise();
@@ -121,6 +121,24 @@ namespace RSG.Tests
 
             Assert.Equal(1f, progressA);
             Assert.Equal(2f, progressB);
+        }
+
+        [Fact]
+        public void exception_is_thrown_for_progress_after_resolve()
+        {
+            var promise = new Promise();
+            promise.Resolve();
+
+            Assert.Throws<ApplicationException>(() => promise.ReportProgress(1f));
+        }
+
+        [Fact]
+        public void exception_is_thrown_for_progress_after_reject()
+        {
+            var promise = new Promise();
+            promise.Reject(new ApplicationException());
+
+            Assert.Throws<ApplicationException>(() => promise.ReportProgress(1f));
         }
     }
 }

--- a/Tests/PromiseProgressTests.cs
+++ b/Tests/PromiseProgressTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 
 namespace RSG.Tests
@@ -203,6 +203,25 @@ namespace RSG.Tests
             promiseB.ReportProgress(0.5f);
 
             Assert.Equal(6, reportCount);
+        }
+
+        [Fact]
+        public void all_progress_with_resolved()
+        {
+            var promiseA = new Promise<int>();
+            var promiseB = Promise<int>.Resolved(17);
+            int reportedCount = 0;
+
+            Promise<int>.All(new IPromise<int>[] { promiseA, promiseB })
+                .Progress(progress =>
+                {
+                    ++reportedCount;
+                    Assert.Equal(0.75f, progress);
+                });
+
+            promiseA.ReportProgress(0.5f);
+
+            Assert.Equal(1, reportedCount);
         }
     }
 }

--- a/Tests/PromiseProgressTests.cs
+++ b/Tests/PromiseProgressTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using Xunit;
+
+namespace RSG.Tests
+{
+    public class PromiseProgressTests
+    {
+        [Fact]
+        public void can_report_simple_progress()
+        {
+            var expectedStep = 0.25f;
+            var currentProgress = 0f;
+            var promise = new Promise();
+
+            promise.Progress(v =>
+            {
+                Assert.InRange(expectedStep - (v - currentProgress), -Math.E, Math.E);
+                currentProgress = v;
+            });
+
+            for (float progress = 0.25f; progress < 1f; progress += 0.25f)
+                promise.ReportProgress(progress);
+            promise.ReportProgress(1f);
+
+            Assert.Equal(1f, currentProgress);
+        }
+
+        [Fact]
+        public void can_handle_onProgress()
+        {
+            var promise = new Promise();
+            var progress = 0f;
+
+            promise.Then(null, null, v => progress = v);
+
+            promise.ReportProgress(1f);
+
+            Assert.Equal(1f, progress);
+        }
+
+        [Fact]
+        public void can_handle_chained_onProgress()
+        {
+            var promiseA = new Promise();
+            var promiseB = new Promise();
+            var progressA = 0f;
+            var progressB = 0f;
+
+            promiseA
+                .Then(() => promiseB, null, v => progressA = v)
+                .Progress(v => progressB = v)
+                .Done();
+
+            promiseA.ReportProgress(1f);
+            promiseA.Resolve();
+            promiseB.ReportProgress(2f);
+            promiseB.Resolve();
+
+            Assert.Equal(1f, progressA);
+            Assert.Equal(2f, progressB);
+        }
+
+        [Fact]
+        public void can_do_weighted_average()
+        {
+            var promiseA = new Promise();
+            var promiseB = new Promise();
+            var promiseC = new Promise();
+
+            var expectedSteps = new float[] { 0.1f, 0.2f, 0.6f, 1f };
+            var currentProgress = 0f;
+            int currentStep = 0;
+
+            promiseC.
+                Progress(v =>
+                {
+                    Assert.InRange(currentStep, 0, expectedSteps.Length - 1);
+                    Assert.Equal(v, expectedSteps[currentStep]);
+                    currentProgress = v;
+                    ++currentStep;
+                })
+            ;
+
+            promiseA.
+                Progress(v => promiseC.ReportProgress(v * 0.2f))
+                .Then(() => promiseB)
+                .Progress(v => promiseC.ReportProgress(0.2f + 0.8f * v))
+                .Then(() => promiseC.Resolve())
+                .Catch(ex => promiseC.Reject(ex))
+            ;
+
+            promiseA.ReportProgress(0.5f);
+            promiseA.ReportProgress(1f);
+            promiseA.Resolve();
+            promiseB.ReportProgress(0.5f);
+            promiseB.ReportProgress(1f);
+            promiseB.Resolve();
+
+            Assert.Equal(1f, currentProgress);
+        }
+
+
+        [Fact]
+        public void chain_multiple_promises_reporting_progress()
+        {
+            var promiseA = new Promise();
+            var promiseB = new Promise();
+            var progressA = 0f;
+            var progressB = 0f;
+
+            promiseA
+                .Progress(v => progressA = v)
+                .Then(() => promiseB)
+                .Progress(v => progressB = v)
+                .Done();
+
+            promiseA.ReportProgress(1f);
+            promiseA.Resolve();
+            promiseB.ReportProgress(2f);
+            promiseB.Resolve();
+
+            Assert.Equal(1f, progressA);
+            Assert.Equal(2f, progressB);
+        }
+    }
+}

--- a/Tests/Promise_NonGeneric_ProgressTests.cs
+++ b/Tests/Promise_NonGeneric_ProgressTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 
 namespace RSG.Tests
@@ -192,6 +192,25 @@ namespace RSG.Tests
             promiseB.ReportProgress(0.5f);
 
             Assert.Equal(6, reportCount);
+        }
+
+        [Fact]
+        public void all_progress_with_resolved()
+        {
+            var promiseA = new Promise();
+            var promiseB = Promise.Resolved();
+            int reportedCount = 0;
+
+            Promise.All(new IPromise[] { promiseA, promiseB })
+                .Progress(progress =>
+                {
+                    ++reportedCount;
+                    Assert.Equal(0.75f, progress);
+                });
+
+            promiseA.ReportProgress(0.5f);
+
+            Assert.Equal(1, reportedCount);
         }
     }
 }


### PR DESCRIPTION
I needed to be able to report progress through promises, so I modified your library to add support for this.
~~Progress reporting is always propagated through the whole chain of promises.
You can modify the progress value at any point of the chain if you intend to, for example, average the progress of two promises. For example:~~

```csharp
IPromise loadAsset(string bundle, string asset)
{
    var promise = new Promise();
    LoadBundle(bundle)
    .Progress(v => promise.ReportProgress(v * 0.5f))
    .Then(b => LoadAssetFromBundle(b, asset))
    .Progress(v => promise.ReportProgress(0.5f + v * 0.5f))
    .Then(() => promise.Resolve())
    .Catch(ex => promise.Reject(ex));
    return promise;
}

loadAsset("bundle", "asset").Progress(v => Debug.Log("Progress: " + v));
```