### PR TITLE
Make Promise.Sequence report progress.

### DIFF
--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -1,4 +1,4 @@
-using RSG.Promises;
+﻿using RSG.Promises;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1028,8 +1028,7 @@ namespace RSG
                 }
             )
             .Then(() => promise.Resolve())
-            .Catch(promise.Reject)
-            .Done();
+            .Catch(promise.Reject);
 
             return promise;
         }

--- a/Tests/Promise_NonGeneric_ProgressTests.cs
+++ b/Tests/Promise_NonGeneric_ProgressTests.cs
@@ -213,5 +213,41 @@ namespace RSG.Tests
 
             Assert.Equal(1, reportedCount);
         }
+
+        [Fact]
+        public void sequence_reports_progress()
+        {
+            var promiseA = new Promise();
+            var promiseB = new Promise();
+            var promiseC = Promise.Resolved();
+            var promiseD = new Promise();
+            int currentReport = 0;
+            var expectedProgress = new[] { 0.125f, 0.25f, 0.25f, 0.3125f, 0.375f, 0.4375f, 0.5f, 0.75f, 0.875f, 1f };
+
+            Promise
+                .Sequence(() => promiseA, () => promiseB, () => promiseC, () => promiseD)
+                .Progress(v =>
+                {
+                    Assert.Equal(expectedProgress[currentReport], v);
+                    ++currentReport;
+                })
+                .Done()
+            ;
+
+            promiseA.ReportProgress(0.5f);
+            promiseA.ReportProgress(1f);
+            promiseA.Resolve();
+
+            promiseB.ReportProgress(0.25f);
+            promiseB.ReportProgress(0.5f);
+            promiseB.ReportProgress(0.75f);
+            promiseB.Resolve();
+
+            promiseD.ReportProgress(0.5f);
+            promiseD.ReportProgress(1f);
+            promiseD.Resolve();
+
+            Assert.Equal(expectedProgress.Length, currentReport);
+        }
     }
 }


### PR DESCRIPTION
Promise.Sequence was not reporting progress. Now it will report an overall progress for the whole sequence going from 0 to 1, plus all the intermediate values inbetween.

This is, if you have 4 promises reporting their own progress (from 0 to 1) in a sequence, the progress that the Promise.Sequence call will report is:
Promise1: [0, 0.25]
Promise2: [0.25, 0.5]
Promise3: [0.5, 0.75]
Promise4: [0.75, 1]
