### PR TITLE
Fix do not report progress on a resolved/rejected promise in Race

### DIFF
--- a/Promise.cs
+++ b/Promise.cs
@@ -954,8 +954,11 @@ namespace RSG
                 promise
                     .Progress(v =>
                     {
-                        progress[index] = v;
-                        resultPromise.ReportProgress(progress.Max());
+                        if (resultPromise.CurState == PromiseState.Pending)
+                        {
+                            progress[index] = v;
+                            resultPromise.ReportProgress(progress.Max());
+                        }
                     })
                     .Then(result =>
                     {


### PR DESCRIPTION
This is a fix to an bug introduced after progress reporting was added, implementation of Race was reporting progress on resolved/rejected promises.