### PR TITLE
Fixed Promise.All trying to still report progress or resolve the result promise when one of the given promises has already reported rejection.

### DIFF
--- a/Promise.cs
+++ b/Promise.cs
@@ -872,7 +872,10 @@ namespace RSG
                     .Progress(v =>
                     {
                         progress[index] = v;
-                        resultPromise.ReportProgress(progress.Average());
+                        if (resultPromise.CurState == PromiseState.Pending)
+                        {
+                            resultPromise.ReportProgress(progress.Average());
+                        }
                     })
                     .Then(result =>
                     {
@@ -880,7 +883,7 @@ namespace RSG
                         results[index] = result;
 
                         --remainingCount;
-                        if (remainingCount <= 0)
+                        if (remainingCount <= 0 && resultPromise.CurState == PromiseState.Pending)
                         {
                             // This will never happen if any of the promises errorred.
                             resultPromise.Resolve(results);

--- a/Promise_NonGeneric.cs
+++ b/Promise_NonGeneric.cs
@@ -1,4 +1,4 @@
-﻿using RSG.Promises;
+using RSG.Promises;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -948,14 +948,17 @@ namespace RSG
                     .Progress(v =>
                     {
                         progress[index] = v;
-                        resultPromise.ReportProgress(progress.Average());
+                        if (resultPromise.CurState == PromiseState.Pending)
+                        {
+                            resultPromise.ReportProgress(progress.Average());
+                        }
                     })
                     .Then(() =>
                     {
                         progress[index] = 1f;
 
                         --remainingCount;
-                        if (remainingCount <= 0)
+                        if (remainingCount <= 0 && resultPromise.CurState == PromiseState.Pending)
                         {
                             // This will never happen if any of the promises errorred.
                             resultPromise.Resolve();


### PR DESCRIPTION
You can reproduce with:

`Promise.All(pending_promise_that_will_report_progress, Promise.Rejected(new Exception()))`