### PR TITLE
Updated build script to create Release assemblies as output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ install:
   - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
  
 script:
-  - msbuild /p:Configuration=Debug C-Sharp-Promise.sln
+  - msbuild /p:Configuration=Release C-Sharp-Promise.sln
   - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.exe ./bin/Debug/RSG.Promise.Tests.dll


### PR DESCRIPTION
This should fix https://github.com/Real-Serious-Games/C-Sharp-Promise/issues/84.

The build script is updated to create release assemblies as CI output. If I'm correct this should result in release assemblies pushed to NuGet package. Hopefully this will fix the issue linked above.