### PR TITLE
Factory methods for Promise creation

### DIFF
--- a/Tests/Promise_NonGeneric_Tests.cs
+++ b/Tests/Promise_NonGeneric_Tests.cs
@@ -1295,5 +1295,48 @@ namespace RSG.Tests
 
             Assert.Equal(2, callback);
         }
+
+        [Fact]
+        public void can_create_promise()
+        {
+            int callback = 0;
+
+            IPromise Create() => Promise.Create((resolve, reject) =>
+            {
+                resolve();
+                ++callback;
+            });
+
+            var promise = new Promise();
+            promise.Then(Create);
+            promise.Resolve();
+
+            Assert.Equal(1, callback);
+        }
+
+        [Fact]
+        public void can_create_oft_promise()
+        {
+            int callback = 0;
+
+            IPromise<int> Create() => Promise.Create<int>((resolve, reject) =>
+            {
+                resolve(1);
+                ++callback;
+            });
+
+            var promise = new Promise();
+            promise.Then(Create);
+            promise.Resolve();
+
+            Assert.Equal(1, callback);
+        }
+
+        [Fact]
+        public void can_create_null_throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => Promise.Create(null));
+            Assert.Throws<ArgumentNullException>(() => Promise.Create<int>(null));
+        }
     }
 }

--- a/src/Promise_NonGeneric.cs
+++ b/src/Promise_NonGeneric.cs
@@ -376,6 +376,22 @@ namespace RSG
         }
 
         /// <summary>
+        /// Create a new promise with no result.
+        /// </summary>
+        /// <param name="resolver">resolve action</param>
+        /// <returns>the constructed promise</returns>
+        public static IPromise Create(Action<Action, Action<Exception>> resolver)
+                => new Promise(resolver ?? throw new ArgumentNullException(nameof(resolver)));
+
+        /// <summary>
+        /// Create a new promise with a result.
+        /// </summary>
+        /// <param name="resolver">resolve action</param>
+        /// <returns>the constructed promise</returns>
+        public static IPromise<T> Create<T>(Action<Action<T>, Action<Exception>> resolver)
+            => new Promise<T>(resolver ?? throw new ArgumentNullException(nameof(resolver)));
+
+        /// <summary>
         /// Increments the ID counter and gives us the ID for the next promise.
         /// </summary>
         internal static int NextId()


### PR DESCRIPTION
I added some factory methods to create the Promises. This prevents the need of casts in some Then(...) constructions:

old
`.Then(() => (IPromise) new Promise((resolve, reject) => ....))`

new
`.Then(() => Promise.Create((resolve, reject) => ....))`