### PR TITLE
Add overload of Catch that returns an IPromise or IPromise<PromisedT>…

### DIFF
--- a/Tests/PromiseTests.cs
+++ b/Tests/PromiseTests.cs
@@ -202,7 +202,7 @@ namespace RSG.Tests
         {
             var promise = new Promise<int>();
 
-            promise.Catch(e => throw new Exception("This shouldn't happen"));
+            promise.Catch(onRejected: e => throw new Exception("This shouldn't happen"));
 
             promise.Resolve(5);
         }
@@ -1471,6 +1471,66 @@ namespace RSG.Tests
                 .Catch(ex => actualException = ex);
 
             Assert.Equal(expectedException, actualException);
+        }
+
+        [Fact]
+        public void rejected_catch_returning_resolved_promise_state_is_adopted()
+        {
+            var promise = new Promise<int>();
+            int expectedValue = 1;
+            int actualValue = 0;
+
+            promise.Catch(err => Promise<int>.Resolved(expectedValue))
+                   .Then(result => { actualValue = result; });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void rejected_catch_returning_rejected_promise_state_is_adopted()
+        {
+            var promise = new Promise<int>();
+            int expectedValue = 1;
+            int actualValue = 0;
+
+            promise.Catch(err => Promise<int>.Rejected(new Exception()))
+                   .Catch(err => actualValue = expectedValue);
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void rejected_catch_returning_resolved_promise_state_is_adopted_nongeneric()
+        {
+            var promise = new Promise();
+            int expectedValue = 1;
+            int actualValue = 0;
+
+            promise.Catch(err => Promise.Resolved())
+                   .Then(() => { actualValue = expectedValue; });
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void rejected_catch_returning_rejected_promise_state_is_adopted_nongeneric()
+        {
+            var promise = new Promise();
+            int expectedValue = 1;
+            int actualValue = 0;
+
+            promise.Catch(err => Promise.Rejected(new Exception()))
+                   .Catch(err => actualValue = expectedValue);
+
+            promise.Reject(new Exception());
+
+            Assert.Equal(expectedValue, actualValue);
         }
     }
 }

--- a/src/Promise.cs
+++ b/src/Promise.cs
@@ -52,6 +52,11 @@ namespace RSG
         IPromise<PromisedT> Catch(Func<Exception, PromisedT> onRejected);
 
         /// <summary>
+        /// Handle errors for the promise and adopt status of returned promise..
+        /// </summary>
+        IPromise<PromisedT> Catch(Func<Exception, IPromise<PromisedT>> rejectionHandler);
+
+        /// <summary>
         /// Add a resolved callback that chains a value promise (optionally converting to a different value type).
         /// </summary>
         IPromise<ConvertedT> Then<ConvertedT>(Func<PromisedT, IPromise<ConvertedT>> onResolved);
@@ -589,6 +594,35 @@ namespace RSG
                 try
                 {
                     resultPromise.Resolve(onRejected(ex));
+                }
+                catch (Exception cbEx)
+                {
+                    resultPromise.Reject(cbEx);
+                }
+            };
+
+            ActionHandlers(resultPromise, resolveHandler, rejectHandler);
+            ProgressHandlers(resultPromise, v => resultPromise.ReportProgress(v));
+
+            return resultPromise;
+        }
+
+        /// <summary>
+        /// Handle errors for the promise and adopt status of returned promise..
+        /// </summary>
+        public IPromise<PromisedT> Catch(Func<Exception, IPromise<PromisedT>> recoveryMethod) {
+            var resultPromise = new Promise<PromisedT>();
+            resultPromise.WithName(Name);
+
+            Action<PromisedT> resolveHandler = v => resultPromise.Resolve(v);
+
+            Action<Exception> rejectHandler = ex =>
+            {
+                try {
+                    recoveryMethod(ex)
+                        .Progress(progress => resultPromise.ReportProgress(progress))
+                        .Then(resolve => resultPromise.Resolve(resolve))
+                        .Catch(reject => resultPromise.Reject(ex));
                 }
                 catch (Exception cbEx)
                 {


### PR DESCRIPTION
… to allow asynchronous continuation

These versions of Catch allow for recovery of a chain of promises by
handling an error from an earlier state, then getting back into the
"normal" flow of processing.

Rework of PR #77.